### PR TITLE
Expand dictionary with restaurant vocabulary and metadata updates

### DIFF
--- a/data/dictionary/adjectives/descriptive.json
+++ b/data/dictionary/adjectives/descriptive.json
@@ -1,12 +1,563 @@
 {
-  "piękny": {
-    "lemma": "piękny",
+  "aromatyczny": {
+    "applied_rules": [
+      "cz",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Ta kawa jest bardzo aromatyczna.",
+        "ru": "Этот кофе очень ароматный.",
+        "ru_transcription": "та кава ест бардзо ароматЫчна."
+      },
+      {
+        "pl": "Aromatyczne zioła.",
+        "ru": "Ароматные травы.",
+        "ru_transcription": "ароматЫчнэ зЁва."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "aromatyczną",
+        "dative": "aromatycznej",
+        "genitive": "aromatycznej",
+        "instrumental": "aromatyczną",
+        "locative": "aromatycznej",
+        "nominative": "aromatyczna",
+        "vocative": "aromatyczna"
+      },
+      "masculine": {
+        "accusative": "aromatyczny/aromatycznego",
+        "dative": "aromatycznemu",
+        "genitive": "aromatycznego",
+        "instrumental": "aromatycznym",
+        "locative": "aromatycznym",
+        "nominative": "aromatyczny",
+        "vocative": "aromatyczny"
+      },
+      "neuter": {
+        "accusative": "aromatyczne",
+        "dative": "aromatycznemu",
+        "genitive": "aromatycznego",
+        "instrumental": "aromatycznym",
+        "locative": "aromatycznym",
+        "nominative": "aromatyczne",
+        "vocative": "aromatyczne"
+      }
+    },
+    "lemma": "aromatyczny",
+    "morphology": {
+      "gradable": true
+    },
     "part_of_speech": "adjective",
-    "translations": { "ru": "красивый" }
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "aromatyczna",
+          "ru": "ароматЫчна"
+        },
+        {
+          "pl": "aromatyczne",
+          "ru": "ароматЫчнэ"
+        }
+      ],
+      "ru_transcription": "ароматЫчны"
+    },
+    "translations": {
+      "ru": "ароматный"
+    }
+  },
+  "cytrynowy": {
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Cytrynowa tarta.",
+        "ru": "Лимонный торт.",
+        "ru_transcription": "цытрынОва тарта."
+      },
+      {
+        "pl": "Cytrynowy sos.",
+        "ru": "Лимонный соус.",
+        "ru_transcription": "цытрынОвы сос."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "cytrynową",
+        "dative": "cytrynowej",
+        "genitive": "cytrynowej",
+        "instrumental": "cytrynową",
+        "locative": "cytrynowej",
+        "nominative": "cytrynowa",
+        "vocative": "cytrynowa"
+      },
+      "masculine": {
+        "accusative": "cytrynowy/cytrynowego",
+        "dative": "cytrynowemu",
+        "genitive": "cytrynowego",
+        "instrumental": "cytrynowym",
+        "locative": "cytrynowym",
+        "nominative": "cytrynowy",
+        "vocative": "cytrynowy"
+      },
+      "neuter": {
+        "accusative": "cytrynowe",
+        "dative": "cytrynowemu",
+        "genitive": "cytrynowego",
+        "instrumental": "cytrynowym",
+        "locative": "cytrynowym",
+        "nominative": "cytrynowe",
+        "vocative": "cytrynowe"
+      }
+    },
+    "lemma": "cytrynowy",
+    "morphology": {
+      "gradable": false
+    },
+    "part_of_speech": "adjective",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "cytrynowa",
+          "ru": "цытрынОва"
+        },
+        {
+          "pl": "cytrynowe",
+          "ru": "цытрынОвэ"
+        }
+      ],
+      "ru_transcription": "цытрынОвы"
+    },
+    "translations": {
+      "ru": "лимонный"
+    }
+  },
+  "delikatny": {
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Ma delikatny smak.",
+        "ru": "Имеет деликатный вкус.",
+        "ru_transcription": "ма дэликАтны смак."
+      },
+      {
+        "pl": "Delikatna skóra.",
+        "ru": "Деликатная кожа.",
+        "ru_transcription": "дэликАтна скура."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "delikatną",
+        "dative": "delikatnej",
+        "genitive": "delikatnej",
+        "instrumental": "delikatną",
+        "locative": "delikatnej",
+        "nominative": "delikatna",
+        "vocative": "delikatna"
+      },
+      "masculine": {
+        "accusative": "delikatny/delikatnego",
+        "dative": "delikatnemu",
+        "genitive": "delikatnego",
+        "instrumental": "delikatnym",
+        "locative": "delikatnym",
+        "nominative": "delikatny",
+        "vocative": "delikatny"
+      },
+      "neuter": {
+        "accusative": "delikatne",
+        "dative": "delikatnemu",
+        "genitive": "delikatnego",
+        "instrumental": "delikatnym",
+        "locative": "delikatnym",
+        "nominative": "delikatne",
+        "vocative": "delikatne"
+      }
+    },
+    "lemma": "delikatny",
+    "morphology": {
+      "gradable": true
+    },
+    "part_of_speech": "adjective",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "delikatna",
+          "ru": "дэликАтна"
+        },
+        {
+          "pl": "delikatne",
+          "ru": "дэликАтнэ"
+        }
+      ],
+      "ru_transcription": "дэликАтны"
+    },
+    "translations": {
+      "ru": "деликатный"
+    }
+  },
+  "gazowany": {
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Woda gazowana czy niegazowana?",
+        "ru": "Вода газированная или негазированная?",
+        "ru_transcription": "вода газОвана чы нЭгазОвана?"
+      },
+      {
+        "pl": "Napój gazowany.",
+        "ru": "Газированный напиток.",
+        "ru_transcription": "напуй газОваны."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "gazowaną",
+        "dative": "gazowanej",
+        "genitive": "gazowanej",
+        "instrumental": "gazowaną",
+        "locative": "gazowanej",
+        "nominative": "gazowana",
+        "vocative": "gazowana"
+      },
+      "masculine": {
+        "accusative": "gazowany/gazowanego",
+        "dative": "gazowanemu",
+        "genitive": "gazowanego",
+        "instrumental": "gazowanym",
+        "locative": "gazowanym",
+        "nominative": "gazowany",
+        "vocative": "gazowany"
+      },
+      "neuter": {
+        "accusative": "gazowane",
+        "dative": "gazowanemu",
+        "genitive": "gazowanego",
+        "instrumental": "gazowanym",
+        "locative": "gazowanym",
+        "nominative": "gazowane",
+        "vocative": "gazowane"
+      }
+    },
+    "lemma": "gazowany",
+    "morphology": {
+      "gradable": false
+    },
+    "part_of_speech": "adjective",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "gazowana",
+          "ru": "газОвана"
+        },
+        {
+          "pl": "gazowane",
+          "ru": "газОванэ"
+        }
+      ],
+      "ru_transcription": "газОваны"
+    },
+    "translations": {
+      "ru": "газированный"
+    }
+  },
+  "gorący": {
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Gorąca herbata.",
+        "ru": "Горячий чай.",
+        "ru_transcription": "гоРОнца хэрбата."
+      },
+      {
+        "pl": "Jest bardzo gorąco.",
+        "ru": "Очень жарко.",
+        "ru_transcription": "ест бардзо гоРОнцо."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "gorącą",
+        "dative": "gorącej",
+        "genitive": "gorącej",
+        "instrumental": "gorącą",
+        "locative": "gorącej",
+        "nominative": "gorąca",
+        "vocative": "gorąca"
+      },
+      "masculine": {
+        "accusative": "gorący/gorącego",
+        "dative": "gorącemu",
+        "genitive": "gorącego",
+        "instrumental": "gorącym",
+        "locative": "gorącym",
+        "nominative": "gorący",
+        "vocative": "gorący"
+      },
+      "neuter": {
+        "accusative": "gorące",
+        "dative": "gorącemu",
+        "genitive": "gorącego",
+        "instrumental": "gorącym",
+        "locative": "gorącym",
+        "nominative": "gorące",
+        "vocative": "gorące"
+      }
+    },
+    "lemma": "gorący",
+    "morphology": {
+      "gradable": true
+    },
+    "part_of_speech": "adjective",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "gorąca",
+          "ru": "гоРОнца"
+        },
+        {
+          "pl": "gorące",
+          "ru": "гоРОнцэ"
+        }
+      ],
+      "ru_transcription": "гоРОнцы"
+    },
+    "translations": {
+      "ru": "горячий"
+    }
   },
   "interesujący": {
     "lemma": "interesujący",
     "part_of_speech": "adjective",
-    "translations": { "ru": "интересный" }
+    "translations": {
+      "ru": "интересный"
+    }
+  },
+  "kokosowy": {
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Mleko kokosowe.",
+        "ru": "Кокосовое молоко.",
+        "ru_transcription": "млЭко кокосОвэ."
+      },
+      {
+        "pl": "Deser kokosowy.",
+        "ru": "Кокосовый десерт.",
+        "ru_transcription": "дэсэр кокосОвы."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "kokosową",
+        "dative": "kokosowej",
+        "genitive": "kokosowej",
+        "instrumental": "kokosową",
+        "locative": "kokosowej",
+        "nominative": "kokosowa",
+        "vocative": "kokosowa"
+      },
+      "masculine": {
+        "accusative": "kokosowy/kokosowego",
+        "dative": "kokosowemu",
+        "genitive": "kokosowego",
+        "instrumental": "kokosowym",
+        "locative": "kokosowym",
+        "nominative": "kokosowy",
+        "vocative": "kokosowy"
+      },
+      "neuter": {
+        "accusative": "kokosowe",
+        "dative": "kokosowemu",
+        "genitive": "kokosowego",
+        "instrumental": "kokosowym",
+        "locative": "kokosowym",
+        "nominative": "kokosowe",
+        "vocative": "kokosowe"
+      }
+    },
+    "lemma": "kokosowy",
+    "morphology": {
+      "gradable": false
+    },
+    "part_of_speech": "adjective",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "kokosowa",
+          "ru": "кокосОва"
+        },
+        {
+          "pl": "kokosowe",
+          "ru": "кокосОвэ"
+        }
+      ],
+      "ru_transcription": "кокосОвы"
+    },
+    "translations": {
+      "ru": "кокосовый"
+    }
+  },
+  "kremowy": {
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Sos kremowy.",
+        "ru": "Кремовый соус.",
+        "ru_transcription": "сос крэмОвы."
+      },
+      {
+        "pl": "Zupa kremowa.",
+        "ru": "Крем-суп.",
+        "ru_transcription": "зупа крэмОва."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "kremową",
+        "dative": "kremowej",
+        "genitive": "kremowej",
+        "instrumental": "kremową",
+        "locative": "kremowej",
+        "nominative": "kremowa",
+        "vocative": "kremowa"
+      },
+      "masculine": {
+        "accusative": "kremowy/kremowego",
+        "dative": "kremowemu",
+        "genitive": "kremowego",
+        "instrumental": "kremowym",
+        "locative": "kremowym",
+        "nominative": "kremowy",
+        "vocative": "kremowy"
+      },
+      "neuter": {
+        "accusative": "kremowe",
+        "dative": "kremowemu",
+        "genitive": "kremowego",
+        "instrumental": "kremowym",
+        "locative": "kremowym",
+        "nominative": "kremowe",
+        "vocative": "kremowe"
+      }
+    },
+    "lemma": "kremowy",
+    "morphology": {
+      "gradable": false
+    },
+    "part_of_speech": "adjective",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "kremowa",
+          "ru": "крэмОва"
+        },
+        {
+          "pl": "kremowe",
+          "ru": "крэмОвэ"
+        }
+      ],
+      "ru_transcription": "крэмОвы"
+    },
+    "translations": {
+      "ru": "кремовый"
+    }
+  },
+  "piękny": {
+    "lemma": "piękny",
+    "part_of_speech": "adjective",
+    "translations": {
+      "ru": "красивый"
+    }
+  },
+  "przepyszny": {
+    "applied_rules": [
+      "rz",
+      "sz",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "To jest przepyszne!",
+        "ru": "Это превосходно!",
+        "ru_transcription": "то ест пшЭпышнэ!"
+      },
+      {
+        "pl": "Przepyszny deser.",
+        "ru": "Превосходный десерт.",
+        "ru_transcription": "пшЭпышны дэсэр."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "przepyszną",
+        "dative": "przepysznej",
+        "genitive": "przepysznej",
+        "instrumental": "przepyszną",
+        "locative": "przepysznej",
+        "nominative": "przepyszna",
+        "vocative": "przepyszna"
+      },
+      "masculine": {
+        "accusative": "przepyszny/przepysznego",
+        "dative": "przepysznemu",
+        "genitive": "przepysznego",
+        "instrumental": "przepysznym",
+        "locative": "przepysznym",
+        "nominative": "przepyszny",
+        "vocative": "przepyszny"
+      },
+      "neuter": {
+        "accusative": "przepyszne",
+        "dative": "przepysznemu",
+        "genitive": "przepysznego",
+        "instrumental": "przepysznym",
+        "locative": "przepysznym",
+        "nominative": "przepyszne",
+        "vocative": "przepyszne"
+      }
+    },
+    "lemma": "przepyszny",
+    "morphology": {
+      "gradable": true
+    },
+    "part_of_speech": "adjective",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "przepyszna",
+          "ru": "пшЭпышна"
+        },
+        {
+          "pl": "przepyszne",
+          "ru": "пшЭпышнэ"
+        }
+      ],
+      "ru_transcription": "пшЭпышны"
+    },
+    "translations": {
+      "ru": "превосходный"
+    }
   }
 }

--- a/data/dictionary/adverbs/basic.json
+++ b/data/dictionary/adverbs/basic.json
@@ -1,89 +1,443 @@
 {
-  "bardzo": {
-    "lemma": "bardzo",
-    "part_of_speech": "adverb",
-    "translations": { "ru": "очень" },
-    "pronunciation": { 
-      "ru_transcription": "бардзо",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
+  "bardziej": {
+    "applied_rules": [],
     "examples": [
-      { "pl": "To jest bardzo dobre.", "ru": "Это очень хорошо.", "ru_transcription": "то ест бардзо добрэ." },
-      { "pl": "Bardzo mi miło.", "ru": "Очень приятно.", "ru_transcription": "бардзо ми миВО." }
+      {
+        "pl": "To jest bardziej skomplikowane.",
+        "ru": "Это более сложно.",
+        "ru_transcription": "то ест барДЗЕй скомпликОванэ."
+      },
+      {
+        "pl": "Bardziej mi się podoba.",
+        "ru": "Мне больше нравится.",
+        "ru_transcription": "барДЗЕй ми сЯ подоба."
+      }
     ],
+    "inflection": {},
+    "lemma": "bardziej",
+    "morphology": {},
+    "part_of_speech": "adverb",
     "phrases_and_idioms": [],
-    "applied_rules": []
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "барДЗЕй"
+    },
+    "translations": {
+      "ru": "больше"
+    }
+  },
+  "bardzo": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "To jest bardzo dobre.",
+        "ru": "Это очень хорошо.",
+        "ru_transcription": "то ест бардзо добрэ."
+      },
+      {
+        "pl": "Bardzo mi miło.",
+        "ru": "Очень приятно.",
+        "ru_transcription": "бардзо ми миВО."
+      }
+    ],
+    "inflection": {},
+    "lemma": "bardzo",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "бардзо"
+    },
+    "translations": {
+      "ru": "очень"
+    }
   },
   "dobrze": {
-    "lemma": "dobrze",
-    "part_of_speech": "adverb",
-    "translations": { "ru": "хорошо" },
-    "pronunciation": { 
-      "ru_transcription": "добжэ",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
-    "examples": [
-      { "pl": "Czuję się dobrze.", "ru": "Я чувствую себя хорошо.", "ru_transcription": "чуЁм сЯ добжэ." },
-      { "pl": "Bardzo dobrze!", "ru": "Очень хорошо!", "ru_transcription": "бардзо добжэ!" }
+    "applied_rules": [
+      "rz"
     ],
+    "examples": [
+      {
+        "pl": "Czuję się dobrze.",
+        "ru": "Я чувствую себя хорошо.",
+        "ru_transcription": "чуЁм сЯ добжэ."
+      },
+      {
+        "pl": "Bardzo dobrze!",
+        "ru": "Очень хорошо!",
+        "ru_transcription": "бардзо добжэ!"
+      }
+    ],
+    "inflection": {},
+    "lemma": "dobrze",
+    "morphology": {},
+    "part_of_speech": "adverb",
     "phrases_and_idioms": [],
-    "applied_rules": ["rz"]
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "добжэ"
+    },
+    "translations": {
+      "ru": "хорошо"
+    }
+  },
+  "jeszcze": {
+    "applied_rules": [
+      "sz",
+      "cz"
+    ],
+    "examples": [
+      {
+        "pl": "Jeszcze raz, proszę.",
+        "ru": "Ещё раз, пожалуйста.",
+        "ru_transcription": "ЕшчЭ раз прошэм."
+      },
+      {
+        "pl": "Czy jeszcze coś?",
+        "ru": "Ещё что-нибудь?",
+        "ru_transcription": "чы ЕшчЭ цошь?"
+      }
+    ],
+    "inflection": {},
+    "lemma": "jeszcze",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [
+      {
+        "pl": "jeszcze raz",
+        "ru": "ещё раз"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "ЕшчЭ"
+    },
+    "translations": {
+      "ru": "ещё"
+    }
   },
   "już": {
-    "lemma": "już",
-    "part_of_speech": "adverb",
-    "translations": { "ru": "уже" },
-    "pronunciation": { 
-      "ru_transcription": "юж",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
-    "examples": [
-      { "pl": "Już jestem w domu.", "ru": "Я уже дома.", "ru_transcription": "юж естэм в дому." },
-      { "pl": "Czy już skończyłeś?", "ru": "Ты уже закончил?", "ru_transcription": "чы юж сконьчыВЭш?" }
+    "applied_rules": [
+      "ż"
     ],
+    "examples": [
+      {
+        "pl": "Już jestem w domu.",
+        "ru": "Я уже дома.",
+        "ru_transcription": "юж естэм в дому."
+      },
+      {
+        "pl": "Czy już skończyłeś?",
+        "ru": "Ты уже закончил?",
+        "ru_transcription": "чы юж сконьчыВЭш?"
+      }
+    ],
+    "inflection": {},
+    "lemma": "już",
+    "morphology": {},
+    "part_of_speech": "adverb",
     "phrases_and_idioms": [],
-    "applied_rules": ["ż"]
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "юж"
+    },
+    "translations": {
+      "ru": "уже"
+    }
+  },
+  "kusząco": {
+    "applied_rules": [
+      "sz",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "To wygląda kusząco.",
+        "ru": "Это выглядит соблазнительно.",
+        "ru_transcription": "то выглОнда кушОнцо."
+      },
+      {
+        "pl": "Kusząco pachnie.",
+        "ru": "Соблазнительно пахнет.",
+        "ru_transcription": "кушОнцо пахнЭ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "kusząco",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "кушОнцо"
+    },
+    "translations": {
+      "ru": "соблазнительно"
+    }
+  },
+  "mniej": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Mniej soli, proszę.",
+        "ru": "Меньше соли, пожалуйста.",
+        "ru_transcription": "мнЕй соли прошэм."
+      },
+      {
+        "pl": "To kosztuje mniej.",
+        "ru": "Это стоит меньше.",
+        "ru_transcription": "то коштУЕ мнЕй."
+      }
+    ],
+    "inflection": {},
+    "lemma": "mniej",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "мнЕй"
+    },
+    "translations": {
+      "ru": "меньше"
+    }
+  },
+  "może": {
+    "applied_rules": [
+      "ż"
+    ],
+    "examples": [
+      {
+        "pl": "Może przyjdę jutro.",
+        "ru": "Возможно, приду завтра.",
+        "ru_transcription": "можЭ пшыйдЭм ютро."
+      },
+      {
+        "pl": "Może tak, może nie.",
+        "ru": "Может быть так, а может и нет.",
+        "ru_transcription": "можЭ так можЭ нЭ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "może",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [
+      {
+        "pl": "może być",
+        "ru": "может быть"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "можЭ"
+    },
+    "translations": {
+      "ru": "возможно"
+    }
+  },
+  "niestety": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Niestety nie mamy wolnych stolików.",
+        "ru": "К сожалению, у нас нет свободных столиков.",
+        "ru_transcription": "нЭстЭты нЭ мамы вольных столИкув."
+      },
+      {
+        "pl": "To niestety niemożliwe.",
+        "ru": "К сожалению, это невозможно.",
+        "ru_transcription": "то нЭстЭты нЭможлИвэ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "niestety",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "нЭстЭты"
+    },
+    "translations": {
+      "ru": "к сожалению"
+    }
+  },
+  "oczywiście": {
+    "applied_rules": [
+      "cz",
+      "sz",
+      "ś",
+      "ć"
+    ],
+    "examples": [
+      {
+        "pl": "Oczywiście, że tak!",
+        "ru": "Конечно же, да!",
+        "ru_transcription": "очывИшчЕ жэ так!"
+      },
+      {
+        "pl": "To oczywiście możliwe.",
+        "ru": "Это, конечно, возможно.",
+        "ru_transcription": "то очывИшчЕ можлИвэ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "oczywiście",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "очывИшчЕ"
+    },
+    "translations": {
+      "ru": "конечно"
+    }
+  },
+  "ponownie": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Dziękuję ponownie.",
+        "ru": "Ещё раз благодарю.",
+        "ru_transcription": "дзЁнкуЕм поновНЕ."
+      },
+      {
+        "pl": "Czy możemy spotkać się ponownie?",
+        "ru": "Можем ли мы встретиться снова?",
+        "ru_transcription": "чы можемы споткАч сЯ поновНЕ?"
+      }
+    ],
+    "inflection": {},
+    "lemma": "ponownie",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "поновНЕ"
+    },
+    "translations": {
+      "ru": "повторно"
+    }
   },
   "tak": {
-    "lemma": "tak",
-    "part_of_speech": "adverb",
-    "translations": { "ru": "да, так" },
-    "pronunciation": { 
-      "ru_transcription": "так",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
+    "applied_rules": [],
     "examples": [
-      { "pl": "Tak, to prawda.", "ru": "Да, это правда.", "ru_transcription": "так то правда." },
-      { "pl": "Nie tak!", "ru": "Не так!", "ru_transcription": "нэ так!" }
+      {
+        "pl": "Tak, to prawda.",
+        "ru": "Да, это правда.",
+        "ru_transcription": "так то правда."
+      },
+      {
+        "pl": "Nie tak!",
+        "ru": "Не так!",
+        "ru_transcription": "нэ так!"
+      }
     ],
+    "inflection": {},
+    "lemma": "tak",
+    "morphology": {},
+    "part_of_speech": "adverb",
     "phrases_and_idioms": [
-      { "pl": "tak czy nie", "ru": "да или нет" }
+      {
+        "pl": "tak czy nie",
+        "ru": "да или нет"
+      }
     ],
-    "applied_rules": []
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "так"
+    },
+    "translations": {
+      "ru": "да, так"
+    }
+  },
+  "trochę": {
+    "applied_rules": [
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Trochę soli.",
+        "ru": "Немного соли.",
+        "ru_transcription": "трохЭм соли."
+      },
+      {
+        "pl": "Jestem trochę zmęczony.",
+        "ru": "Я немного устал.",
+        "ru_transcription": "естэм трохЭм змэнчоный."
+      }
+    ],
+    "inflection": {},
+    "lemma": "trochę",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "трохЭм"
+    },
+    "translations": {
+      "ru": "немного"
+    }
   },
   "tylko": {
-    "lemma": "tylko",
-    "part_of_speech": "adverb",
-    "translations": { "ru": "только" },
-    "pronunciation": { 
-      "ru_transcription": "тылько",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
+    "applied_rules": [],
     "examples": [
-      { "pl": "Mam tylko pięć złotych.", "ru": "У меня только пять злотых.", "ru_transcription": "мам тылько пЯнч зВОтых." },
-      { "pl": "To tylko żart.", "ru": "Это только шутка.", "ru_transcription": "то тылько жарт." }
+      {
+        "pl": "Mam tylko pięć złotych.",
+        "ru": "У меня только пять злотых.",
+        "ru_transcription": "мам тылько пЯнч зВОтых."
+      },
+      {
+        "pl": "To tylko żart.",
+        "ru": "Это только шутка.",
+        "ru_transcription": "то тылько жарт."
+      }
     ],
+    "inflection": {},
+    "lemma": "tylko",
+    "morphology": {},
+    "part_of_speech": "adverb",
     "phrases_and_idioms": [],
-    "applied_rules": []
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "тылько"
+    },
+    "translations": {
+      "ru": "только"
+    }
+  },
+  "świetnie": {
+    "applied_rules": [
+      "ś"
+    ],
+    "examples": [
+      {
+        "pl": "Świetnie smakuje!",
+        "ru": "Отлично на вкус!",
+        "ru_transcription": "шьвЕтнЭ смакУЕ!"
+      },
+      {
+        "pl": "To brzmi świetnie.",
+        "ru": "Это звучит отлично.",
+        "ru_transcription": "то бжми шьвЕтнЭ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "świetnie",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "шьвЕтнЭ"
+    },
+    "translations": {
+      "ru": "отлично"
+    }
   }
 }

--- a/data/dictionary/conjunctions/basic.json
+++ b/data/dictionary/conjunctions/basic.json
@@ -1,70 +1,173 @@
 {
-  "i": {
-    "lemma": "i",
-    "part_of_speech": "conjunction",
-    "translations": { "ru": "и" },
-    "pronunciation": { 
-      "ru_transcription": "и",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
+  "a": {
+    "applied_rules": [],
     "examples": [
-      { "pl": "Kawa i herbata.", "ru": "Кофе и чай.", "ru_transcription": "кава и хэрбата." },
-      { "pl": "Ty i ja.", "ru": "Ты и я.", "ru_transcription": "ты и я." }
+      {
+        "pl": "Lubię kawę, a nie herbatę.",
+        "ru": "Люблю кофе, а не чай.",
+        "ru_transcription": "лубЭм кавэ а нЭ хэрбатэ."
+      },
+      {
+        "pl": "Ty jesz, a ja piję.",
+        "ru": "Ты ешь, а я пью.",
+        "ru_transcription": "ты ешь а я пью."
+      }
     ],
+    "inflection": {},
+    "lemma": "a",
+    "morphology": {},
+    "part_of_speech": "conjunction",
     "phrases_and_idioms": [],
-    "applied_rules": []
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "а"
+    },
+    "translations": {
+      "ru": "а"
+    }
   },
   "ale": {
-    "lemma": "ale",
-    "part_of_speech": "conjunction",
-    "translations": { "ru": "но" },
-    "pronunciation": { 
-      "ru_transcription": "алЭ",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
+    "applied_rules": [],
     "examples": [
-      { "pl": "Chcę, ale nie mogę.", "ru": "Хочу, но не могу.", "ru_transcription": "хцэм алЭ нЭ могЭм." },
-      { "pl": "Jest drogo, ale smaczne.", "ru": "Дорого, но вкусно.", "ru_transcription": "ест дрого алЭ смачнэ." }
+      {
+        "pl": "Chcę, ale nie mogę.",
+        "ru": "Хочу, но не могу.",
+        "ru_transcription": "хцэм алЭ нЭ могЭм."
+      },
+      {
+        "pl": "Jest drogo, ale smaczne.",
+        "ru": "Дорого, но вкусно.",
+        "ru_transcription": "ест дрого алЭ смачнэ."
+      }
     ],
+    "inflection": {},
+    "lemma": "ale",
+    "morphology": {},
+    "part_of_speech": "conjunction",
     "phrases_and_idioms": [],
-    "applied_rules": []
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "алЭ"
+    },
+    "translations": {
+      "ru": "но"
+    }
+  },
+  "choć": {
+    "applied_rules": [
+      "ć"
+    ],
+    "examples": [
+      {
+        "pl": "Choć jestem zmęczony, idę.",
+        "ru": "Хотя я устал, иду.",
+        "ru_transcription": "хочь естэм змэнчоны идэм."
+      },
+      {
+        "pl": "Spróbuj, choć trochę.",
+        "ru": "Попробуй хотя бы немного.",
+        "ru_transcription": "спруБУй хочь трохэм."
+      }
+    ],
+    "inflection": {},
+    "lemma": "choć",
+    "morphology": {},
+    "part_of_speech": "conjunction",
+    "phrases_and_idioms": [
+      {
+        "pl": "choćby",
+        "ru": "хотя бы"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "хочь"
+    },
+    "translations": {
+      "ru": "хотя"
+    }
   },
   "czy": {
-    "lemma": "czy",
-    "part_of_speech": "conjunction",
-    "translations": { "ru": "ли, или" },
-    "pronunciation": { 
-      "ru_transcription": "чы",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
+    "applied_rules": [],
     "examples": [
-      { "pl": "Czy jesteś gotowy?", "ru": "Готов ли ты?", "ru_transcription": "чы естЭш готовы?" },
-      { "pl": "Kawa czy herbata?", "ru": "Кофе или чай?", "ru_transcription": "кава чы хэрбата?" }
+      {
+        "pl": "Czy jesteś gotowy?",
+        "ru": "Готов ли ты?",
+        "ru_transcription": "чы естЭш готовы?"
+      },
+      {
+        "pl": "Kawa czy herbata?",
+        "ru": "Кофе или чай?",
+        "ru_transcription": "кава чы хэрбата?"
+      }
     ],
+    "inflection": {},
+    "lemma": "czy",
+    "morphology": {},
+    "part_of_speech": "conjunction",
     "phrases_and_idioms": [],
-    "applied_rules": []
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "чы"
+    },
+    "translations": {
+      "ru": "ли, или"
+    }
+  },
+  "i": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Kawa i herbata.",
+        "ru": "Кофе и чай.",
+        "ru_transcription": "кава и хэрбата."
+      },
+      {
+        "pl": "Ty i ja.",
+        "ru": "Ты и я.",
+        "ru_transcription": "ты и я."
+      }
+    ],
+    "inflection": {},
+    "lemma": "i",
+    "morphology": {},
+    "part_of_speech": "conjunction",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "и"
+    },
+    "translations": {
+      "ru": "и"
+    }
   },
   "że": {
-    "lemma": "że",
-    "part_of_speech": "conjunction",
-    "translations": { "ru": "что" },
-    "pronunciation": { 
-      "ru_transcription": "жэ",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
-    "examples": [
-      { "pl": "Myślę, że to prawda.", "ru": "Думаю, что это правда.", "ru_transcription": "мышлЭм жэ то правда." },
-      { "pl": "Wiem, że przyjdziesz.", "ru": "Знаю, что ты придёшь.", "ru_transcription": "вЕм жэ пшыйдЗЕшь." }
+    "applied_rules": [
+      "ę"
     ],
+    "examples": [
+      {
+        "pl": "Myślę, że to prawda.",
+        "ru": "Думаю, что это правда.",
+        "ru_transcription": "мышлЭм жэ то правда."
+      },
+      {
+        "pl": "Wiem, że przyjdziesz.",
+        "ru": "Знаю, что ты придёшь.",
+        "ru_transcription": "вЕм жэ пшыйдЗЕшь."
+      }
+    ],
+    "inflection": {},
+    "lemma": "że",
+    "morphology": {},
+    "part_of_speech": "conjunction",
     "phrases_and_idioms": [],
-    "applied_rules": ["ę"]
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "жэ"
+    },
+    "translations": {
+      "ru": "что"
+    }
   }
 }

--- a/data/dictionary/index.json
+++ b/data/dictionary/index.json
@@ -1,11 +1,10 @@
 {
   "meta": {
     "version": "1.0.0",
-    "last_updated": "2024-01-15",
-    "total_words": 245,
+    "last_updated": "2025-09-17",
+    "total_words": 129,
     "description": "Интерактивный словарь польского языка с произношением и примерами"
   },
-  
   "categories": {
     "verbs": {
       "name": "Глаголы",
@@ -13,71 +12,68 @@
       "themes": {
         "basic": {
           "file": "verbs/basic.json",
-          "words_count": 15,
+          "words_count": 17,
           "description": "Основные глаголы повседневного общения"
         },
         "restaurant": {
-          "file": "verbs/restaurant.json", 
-          "words_count": 12,
+          "file": "verbs/restaurant.json",
+          "words_count": 8,
           "description": "Глаголы для ресторана и кафе"
         },
         "shop": {
           "file": "verbs/shop.json",
-          "words_count": 10,
+          "words_count": 2,
           "description": "Глаголы для покупок и магазинов"
         }
       }
     },
-    
     "nouns": {
       "name": "Существительные",
       "description": "Польские существительные с падежными формами",
       "themes": {
         "basic": {
           "file": "nouns/basic.json",
-          "words_count": 25,
+          "words_count": 15,
           "description": "Основные существительные"
         },
         "restaurant": {
           "file": "nouns/restaurant.json",
-          "words_count": 18,
+          "words_count": 23,
           "description": "Существительные для ресторана"
         },
         "shop": {
           "file": "nouns/shop.json",
-          "words_count": 15,
+          "words_count": 2,
           "description": "Существительные для магазинов"
         },
         "family": {
           "file": "nouns/family.json",
-          "words_count": 12,
+          "words_count": 0,
           "description": "Семья и родственники"
         }
       }
     },
-    
     "adjectives": {
       "name": "Прилагательные",
       "description": "Польские прилагательные с формами склонения",
       "themes": {
         "basic": {
           "file": "adjectives/basic.json",
-          "words_count": 20,
+          "words_count": 4,
           "description": "Основные прилагательные"
         },
         "descriptive": {
           "file": "adjectives/descriptive.json",
-          "words_count": 25,
+          "words_count": 10,
           "description": "Описательные прилагательные"
         },
         "colors": {
-          "file": "adjectives/colors.json", 
-          "words_count": 12,
+          "file": "adjectives/colors.json",
+          "words_count": 1,
           "description": "Цвета"
         }
       }
     },
-    
     "adverbs": {
       "name": "Наречия",
       "description": "Польские наречия",
@@ -89,71 +85,131 @@
         },
         "time": {
           "file": "adverbs/time.json",
-          "words_count": 10,
+          "words_count": 0,
           "description": "Наречия времени"
         }
       }
     },
-    
     "pronouns": {
       "name": "Местоимения",
       "description": "Польские местоимения",
       "themes": {
         "personal": {
           "file": "pronouns/personal.json",
-          "words_count": 8,
+          "words_count": 3,
           "description": "Личные местоимения"
         },
         "possessive": {
           "file": "pronouns/possessive.json",
-          "words_count": 12,
+          "words_count": 0,
           "description": "Притяжательные местоимения"
+        },
+        "demonstrative": {
+          "file": "pronouns/demonstrative.json",
+          "words_count": 5,
+          "description": "Указательные местоимения"
         }
       }
     },
-    
     "prepositions": {
       "name": "Предлоги",
       "description": "Польские предлоги",
       "themes": {
         "basic": {
           "file": "prepositions/basic.json",
-          "words_count": 15,
+          "words_count": 8,
           "description": "Основные предлоги"
         }
       }
     },
-    
     "conjunctions": {
       "name": "Союзы",
       "description": "Польские союзы",
       "themes": {
         "basic": {
           "file": "conjunctions/basic.json",
-          "words_count": 10,
+          "words_count": 6,
           "description": "Основные союзы"
         }
       }
     },
-    
     "numbers": {
       "name": "Числительные",
       "description": "Польские числительные",
       "themes": {
         "cardinal": {
           "file": "numbers/cardinal.json",
-          "words_count": 20,
+          "words_count": 0,
           "description": "Количественные числительные"
         },
         "ordinal": {
           "file": "numbers/ordinal.json",
-          "words_count": 20,
+          "words_count": 0,
           "description": "Порядковые числительные"
+        },
+        "basic": {
+          "file": "numbers/basic.json",
+          "words_count": 3,
+          "description": "Основные числительные"
+        }
+      }
+    },
+    "modals": {
+      "name": "Модальные слова",
+      "description": "Польские модальные выражения",
+      "themes": {
+        "basic": {
+          "file": "modals/basic.json",
+          "words_count": 1,
+          "description": "Основные модальные слова"
+        }
+      }
+    },
+    "particles": {
+      "name": "Частицы",
+      "description": "Польские частицы",
+      "themes": {
+        "basic": {
+          "file": "particles/basic.json",
+          "words_count": 2,
+          "description": "Основные частицы"
+        }
+      }
+    },
+    "interjections": {
+      "name": "Междометия",
+      "description": "Польские междометия",
+      "themes": {
+        "basic": {
+          "file": "interjections/basic.json",
+          "words_count": 2,
+          "description": "Основные междометия"
+        }
+      }
+    },
+    "interrogatives": {
+      "name": "Вопросительные слова",
+      "description": "Польские вопросительные слова",
+      "themes": {
+        "basic": {
+          "file": "interrogatives/basic.json",
+          "words_count": 1,
+          "description": "Основные вопросительные слова"
+        }
+      }
+    },
+    "punctuation": {
+      "name": "Знаки препинания",
+      "description": "Польские знаки препинания",
+      "themes": {
+        "basic": {
+          "file": "punctuation/basic.json",
+          "words_count": 1,
+          "description": "Основные знаки препинания"
         }
       }
     }
   },
-  
   "tags": {
     "frequency": {
       "most_common": "Самые употребительные слова",
@@ -162,7 +218,7 @@
     },
     "difficulty": {
       "easy": "Легкие для запоминания",
-      "medium": "Средней сложности", 
+      "medium": "Средней сложности",
       "hard": "Сложные"
     },
     "topics": {
@@ -176,14 +232,12 @@
       "entertainment": "Развлечения"
     }
   },
-  
   "search_tips": [
     "Можно искать как по польскому, так и по русскому слову",
     "Поиск работает с частичными совпадениями",
     "Используйте фильтры для уточнения поиска",
     "Кликните на слово в диалоге для получения подробной информации"
   ],
-  
   "learning_features": {
     "pronunciation": {
       "enabled": true,
@@ -206,19 +260,20 @@
       "description": "Аудио произношение (планируется)"
     }
   },
-  
   "statistics": {
     "by_part_of_speech": {
-      "verbs": 37,
-      "nouns": 70,
-      "adjectives": 57,
-      "adverbs": 25,
-      "pronouns": 20,
-      "prepositions": 15,
-      "conjunctions": 10,
-      "numbers": 40,
-      "particles": 8,
-      "interjections": 3
+      "particle": 2,
+      "modal": 1,
+      "punctuation": 1,
+      "interjection": 2,
+      "pronoun": 8,
+      "adjective": 15,
+      "noun": 40,
+      "preposition": 8,
+      "adverb": 16,
+      "numeral": 3,
+      "conjunction": 6,
+      "verb": 27
     },
     "by_difficulty": {
       "A1": 120,
@@ -227,8 +282,16 @@
       "B2": 10
     },
     "most_searched": [
-      "być", "mieć", "chcieć", "móc", "prosić",
-      "stolik", "menu", "rachunek", "kawiarnia", "zupa"
+      "być",
+      "mieć",
+      "chcieć",
+      "móc",
+      "prosić",
+      "stolik",
+      "menu",
+      "rachunek",
+      "kawiarnia",
+      "zupa"
     ]
   }
 }

--- a/data/dictionary/interjections/basic.json
+++ b/data/dictionary/interjections/basic.json
@@ -1,0 +1,56 @@
+{
+  "oto": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Oto menu.",
+        "ru": "Вот меню.",
+        "ru_transcription": "ото мэню."
+      },
+      {
+        "pl": "Oto i ja!",
+        "ru": "А вот и я!",
+        "ru_transcription": "ото и я!"
+      }
+    ],
+    "inflection": {},
+    "lemma": "oto",
+    "morphology": {},
+    "part_of_speech": "interjection",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "ото"
+    },
+    "translations": {
+      "ru": "вот"
+    }
+  },
+  "panie": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Przepraszam panie!",
+        "ru": "Извините, господин!",
+        "ru_transcription": "пшЭпрашам паНЕ!"
+      },
+      {
+        "pl": "Co Pan zamawia, panie?",
+        "ru": "Что Вы заказываете, господин?",
+        "ru_transcription": "цо пан замаВЯ паНЕ?"
+      }
+    ],
+    "inflection": {},
+    "lemma": "panie",
+    "morphology": {},
+    "part_of_speech": "interjection",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "паНЕ"
+    },
+    "translations": {
+      "ru": "господин"
+    }
+  }
+}

--- a/data/dictionary/interrogatives/basic.json
+++ b/data/dictionary/interrogatives/basic.json
@@ -1,0 +1,34 @@
+{
+  "jak": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Jak się masz?",
+        "ru": "Как дела?",
+        "ru_transcription": "як сЯ маш?"
+      },
+      {
+        "pl": "Jak to smakuje?",
+        "ru": "Как это на вкус?",
+        "ru_transcription": "як то смакУЕ?"
+      }
+    ],
+    "inflection": {},
+    "lemma": "jak",
+    "morphology": {},
+    "part_of_speech": "adverb",
+    "phrases_and_idioms": [
+      {
+        "pl": "jak się masz",
+        "ru": "как дела"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "як"
+    },
+    "translations": {
+      "ru": "как"
+    }
+  }
+}

--- a/data/dictionary/modals/basic.json
+++ b/data/dictionary/modals/basic.json
@@ -1,0 +1,31 @@
+{
+  "można": {
+    "applied_rules": [
+      "ż"
+    ],
+    "examples": [
+      {
+        "pl": "Można zapłacić kartą?",
+        "ru": "Можно оплатить картой?",
+        "ru_transcription": "можна запВАцич картОм?"
+      },
+      {
+        "pl": "Tutaj można palić.",
+        "ru": "Здесь можно курить.",
+        "ru_transcription": "тутай можна палич."
+      }
+    ],
+    "inflection": {},
+    "lemma": "można",
+    "morphology": {},
+    "part_of_speech": "modal",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "можна"
+    },
+    "translations": {
+      "ru": "можно"
+    }
+  }
+}

--- a/data/dictionary/nouns/basic.json
+++ b/data/dictionary/nouns/basic.json
@@ -1,282 +1,808 @@
 {
   "chwila": {
-    "lemma": "chwila",
-    "part_of_speech": "noun",
-    "translations": { "ru": "момент, минутка" },
-    "pronunciation": { 
-      "ru_transcription": "хВИля",
-      "key_forms": []
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Poczekaj chwilę.",
+        "ru": "Подожди минутку.",
+        "ru_transcription": "почЭкай хВИлем."
+      },
+      {
+        "pl": "W tej chwili jestem zajęty.",
+        "ru": "В данный момент я занят.",
+        "ru_transcription": "в тэй хВИли естэм заЁнты."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "chwile",
+        "dative": "chwilom",
+        "genitive": "chwil",
+        "instrumental": "chwilami",
+        "locative": "chwilach",
+        "nominative": "chwile",
+        "vocative": "chwile"
+      },
+      "singular": {
+        "accusative": "chwilę",
+        "dative": "chwili",
+        "genitive": "chwili",
+        "instrumental": "chwilą",
+        "locative": "chwili",
+        "nominative": "chwila",
+        "vocative": "chwilo"
+      }
     },
+    "lemma": "chwila",
     "morphology": {
       "gender": "feminine"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "chwila",
-        "genitive": "chwili",
-        "dative": "chwili",
-        "accusative": "chwilę",
-        "instrumental": "chwilą",
-        "locative": "chwili",
-        "vocative": "chwilo"
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [
+      {
+        "pl": "na chwilę",
+        "ru": "на минутку"
       },
+      {
+        "pl": "w tej chwili",
+        "ru": "в данный момент"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "хВИля"
+    },
+    "translations": {
+      "ru": "момент, минутка"
+    }
+  },
+  "cytryna": {
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Dodaj cytrynę do herbaty.",
+        "ru": "Добавь лимон в чай.",
+        "ru_transcription": "додАй цытрЫнэ до хэрбаты."
+      },
+      {
+        "pl": "Ta cytryna jest kwaśna.",
+        "ru": "Этот лимон кислый.",
+        "ru_transcription": "та цытрЫна ест квашна."
+      }
+    ],
+    "inflection": {
       "plural": {
-        "nominative": "chwile",
-        "genitive": "chwil",
-        "dative": "chwilom",
-        "accusative": "chwile",
-        "instrumental": "chwilami",
-        "locative": "chwilach",
-        "vocative": "chwile"
+        "accusative": "cytryny",
+        "dative": "cytrynom",
+        "genitive": "cytryn",
+        "instrumental": "cytrynami",
+        "locative": "cytrynach",
+        "nominative": "cytryny",
+        "vocative": "cytryny"
+      },
+      "singular": {
+        "accusative": "cytrynę",
+        "dative": "cytrynie",
+        "genitive": "cytryny",
+        "instrumental": "cytryną",
+        "locative": "cytrynie",
+        "nominative": "cytryna",
+        "vocative": "cytryno"
       }
     },
+    "lemma": "cytryna",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "цытрЫна"
+    },
+    "translations": {
+      "ru": "лимон"
+    }
+  },
+  "dynia": {
+    "applied_rules": [
+      "ń",
+      "ą",
+      "ę"
+    ],
     "examples": [
-      { "pl": "Poczekaj chwilę.", "ru": "Подожди минутку.", "ru_transcription": "почЭкай хВИлем." },
-      { "pl": "W tej chwili jestem zajęty.", "ru": "В данный момент я занят.", "ru_transcription": "в тэй хВИли естэм заЁнты." }
+      {
+        "pl": "Zupa z dyni jest pyszna.",
+        "ru": "Тыквенный суп вкусный.",
+        "ru_transcription": "зупа з дыни ест пышна."
+      },
+      {
+        "pl": "Kupiłem dużą dynię.",
+        "ru": "Купил большую тыкву.",
+        "ru_transcription": "купиВЭм дужОм дыньэ."
+      }
     ],
-    "phrases_and_idioms": [
-      { "pl": "na chwilę", "ru": "на минутку" },
-      { "pl": "w tej chwili", "ru": "в данный момент" }
-    ],
-    "applied_rules": ["ą", "ę"]
+    "inflection": {
+      "plural": {
+        "accusative": "dynie",
+        "dative": "dyniom",
+        "genitive": "dyń",
+        "instrumental": "dyniami",
+        "locative": "dyniach",
+        "nominative": "dynie",
+        "vocative": "dynie"
+      },
+      "singular": {
+        "accusative": "dynię",
+        "dative": "dyni",
+        "genitive": "dyni",
+        "instrumental": "dynią",
+        "locative": "dyni",
+        "nominative": "dynia",
+        "vocative": "dynio"
+      }
+    },
+    "lemma": "dynia",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "дыНЯ"
+    },
+    "translations": {
+      "ru": "тыква"
+    }
   },
   "dzień": {
-    "lemma": "dzień",
-    "part_of_speech": "noun",
-    "translations": { "ru": "день" },
-    "pronunciation": { 
-      "ru_transcription": "джэнь",
-      "key_forms": []
+    "applied_rules": [
+      "ń"
+    ],
+    "examples": [
+      {
+        "pl": "Dobry dzień!",
+        "ru": "Добрый день!",
+        "ru_transcription": "добры джэнь!"
+      },
+      {
+        "pl": "Mam wolny dzień.",
+        "ru": "У меня выходной день.",
+        "ru_transcription": "мам вольны джэнь."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "dni",
+        "dative": "dniom",
+        "genitive": "dni",
+        "instrumental": "dniami",
+        "locative": "dniach",
+        "nominative": "dni",
+        "vocative": "dni"
+      },
+      "singular": {
+        "accusative": "dzień",
+        "dative": "dniowi",
+        "genitive": "dnia",
+        "instrumental": "dniem",
+        "locative": "dniu",
+        "nominative": "dzień",
+        "vocative": "dniu"
+      }
     },
+    "lemma": "dzień",
     "morphology": {
       "gender": "masculine_inanimate"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "dzień",
-        "genitive": "dnia",
-        "dative": "dniowi",
-        "accusative": "dzień",
-        "instrumental": "dniem",
-        "locative": "dniu",
-        "vocative": "dniu"
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [
+      {
+        "pl": "cały dzień",
+        "ru": "весь день"
       },
+      {
+        "pl": "dobry dzień",
+        "ru": "добрый день"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "джэнь"
+    },
+    "translations": {
+      "ru": "день"
+    }
+  },
+  "grzyb": {
+    "applied_rules": [
+      "rz",
+      "ó"
+    ],
+    "examples": [
+      {
+        "pl": "Lubię grzyby w sosie.",
+        "ru": "Люблю грибы в соусе.",
+        "ru_transcription": "лубЭм гжыбы в сошэ."
+      },
+      {
+        "pl": "Grzyby rosną w lesie.",
+        "ru": "Грибы растут в лесу.",
+        "ru_transcription": "гжыбы росном в лешэ."
+      }
+    ],
+    "inflection": {
       "plural": {
-        "nominative": "dni",
-        "genitive": "dni",
-        "dative": "dniom",
-        "accusative": "dni",
-        "instrumental": "dniami",
-        "locative": "dniach",
-        "vocative": "dni"
+        "accusative": "grzyby",
+        "dative": "grzybom",
+        "genitive": "grzybów",
+        "instrumental": "grzybami",
+        "locative": "grzybach",
+        "nominative": "grzyby",
+        "vocative": "grzyby"
+      },
+      "singular": {
+        "accusative": "grzyb",
+        "dative": "grzybowi",
+        "genitive": "grzyba",
+        "instrumental": "grzybem",
+        "locative": "grzybie",
+        "nominative": "grzyb",
+        "vocative": "grzybie"
       }
     },
-    "examples": [
-      { "pl": "Dobry dzień!", "ru": "Добрый день!", "ru_transcription": "добры джэнь!" },
-      { "pl": "Mam wolny dzień.", "ru": "У меня выходной день.", "ru_transcription": "мам вольны джэнь." }
-    ],
-    "phrases_and_idioms": [
-      { "pl": "cały dzień", "ru": "весь день" },
-      { "pl": "dobry dzień", "ru": "добрый день" }
-    ],
-    "applied_rules": ["ń"]
-  },
-  "minuta": {
-    "lemma": "minuta",
-    "part_of_speech": "noun",
-    "translations": { "ru": "минута" },
-    "pronunciation": { 
-      "ru_transcription": "миНУта",
-      "key_forms": []
+    "lemma": "grzyb",
+    "morphology": {
+      "gender": "masculine_inanimate"
     },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "гжыб"
+    },
+    "translations": {
+      "ru": "гриб"
+    }
+  },
+  "herbata": {
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Poproszę herbatę z cytryną.",
+        "ru": "Чай с лимоном, пожалуйста.",
+        "ru_transcription": "попрошэм хэрбатэм з цытрЫнОм."
+      },
+      {
+        "pl": "Ta herbata jest bardzo aromatyczna.",
+        "ru": "Этот чай очень ароматный.",
+        "ru_transcription": "та хэрбата ест бардзо ароматична."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "herbaty",
+        "dative": "herbatom",
+        "genitive": "herbat",
+        "instrumental": "herbatami",
+        "locative": "herbatach",
+        "nominative": "herbaty",
+        "vocative": "herbaty"
+      },
+      "singular": {
+        "accusative": "herbatę",
+        "dative": "herbacie",
+        "genitive": "herbaty",
+        "instrumental": "herbatą",
+        "locative": "herbacie",
+        "nominative": "herbata",
+        "vocative": "herbato"
+      }
+    },
+    "lemma": "herbata",
     "morphology": {
       "gender": "feminine"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "minuta",
-        "genitive": "minuty",
-        "dative": "minucie",
-        "accusative": "minutę",
-        "instrumental": "minutą",
-        "locative": "minucie",
-        "vocative": "minuto"
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [
+      {
+        "pl": "herbata zielona",
+        "ru": "зелёный чай"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "хэрБАта"
+    },
+    "translations": {
+      "ru": "чай"
+    }
+  },
+  "kawałek": {
+    "applied_rules": [
+      "ł",
+      "ó"
+    ],
+    "examples": [
+      {
+        "pl": "Poproszę kawałek tortu.",
+        "ru": "Кусочек торта, пожалуйста.",
+        "ru_transcription": "попрошэм каваВЭк торту."
       },
+      {
+        "pl": "Mały kawałek sera.",
+        "ru": "Маленький кусочек сыра.",
+        "ru_transcription": "мауый каваВЭк сэра."
+      }
+    ],
+    "inflection": {
       "plural": {
-        "nominative": "minuty",
-        "genitive": "minut",
-        "dative": "minutom",
-        "accusative": "minuty",
-        "instrumental": "minutami",
-        "locative": "minutach",
-        "vocative": "minuty"
+        "accusative": "kawałki",
+        "dative": "kawałkom",
+        "genitive": "kawałków",
+        "instrumental": "kawałkami",
+        "locative": "kawałkach",
+        "nominative": "kawałki",
+        "vocative": "kawałki"
+      },
+      "singular": {
+        "accusative": "kawałek",
+        "dative": "kawałkowi",
+        "genitive": "kawałka",
+        "instrumental": "kawałkiem",
+        "locative": "kawałku",
+        "nominative": "kawałek",
+        "vocative": "kawałku"
       }
     },
+    "lemma": "kawałek",
+    "morphology": {
+      "gender": "masculine_inanimate"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "каваВЭк"
+    },
+    "translations": {
+      "ru": "кусочек"
+    }
+  },
+  "koszyk": {
+    "applied_rules": [
+      "sz",
+      "ó"
+    ],
     "examples": [
-      { "pl": "Zostało pięć minut.", "ru": "Осталось пять минут.", "ru_transcription": "зостаўо пэнч минут." },
-      { "pl": "Minutę, proszę.", "ru": "Минутку, пожалуйста.", "ru_transcription": "минутЭм прошэм." }
+      {
+        "pl": "Koszyk na pieczywo.",
+        "ru": "Корзинка для хлеба.",
+        "ru_transcription": "кошЫк на пЕчыво."
+      },
+      {
+        "pl": "Pełny koszyk zakupów.",
+        "ru": "Полная корзина покупок.",
+        "ru_transcription": "пЭуны кошЫк закупув."
+      }
     ],
+    "inflection": {
+      "plural": {
+        "accusative": "koszyki",
+        "dative": "koszykom",
+        "genitive": "koszyków",
+        "instrumental": "koszykami",
+        "locative": "koszykach",
+        "nominative": "koszyki",
+        "vocative": "koszyki"
+      },
+      "singular": {
+        "accusative": "koszyk",
+        "dative": "koszykowi",
+        "genitive": "koszyka",
+        "instrumental": "koszykiem",
+        "locative": "koszyku",
+        "nominative": "koszyk",
+        "vocative": "koszyku"
+      }
+    },
+    "lemma": "koszyk",
+    "morphology": {
+      "gender": "masculine_inanimate"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "кошЫк"
+    },
+    "translations": {
+      "ru": "корзинка"
+    }
+  },
+  "minuta": {
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Zostało pięć minut.",
+        "ru": "Осталось пять минут.",
+        "ru_transcription": "зостаўо пэнч минут."
+      },
+      {
+        "pl": "Minutę, proszę.",
+        "ru": "Минутку, пожалуйста.",
+        "ru_transcription": "минутЭм прошэм."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "minuty",
+        "dative": "minutom",
+        "genitive": "minut",
+        "instrumental": "minutami",
+        "locative": "minutach",
+        "nominative": "minuty",
+        "vocative": "minuty"
+      },
+      "singular": {
+        "accusative": "minutę",
+        "dative": "minucie",
+        "genitive": "minuty",
+        "instrumental": "minutą",
+        "locative": "minucie",
+        "nominative": "minuta",
+        "vocative": "minuto"
+      }
+    },
+    "lemma": "minuta",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
     "phrases_and_idioms": [
-      { "pl": "co minutę", "ru": "каждую минуту" }
+      {
+        "pl": "co minutę",
+        "ru": "каждую минуту"
+      }
     ],
-    "applied_rules": ["ą", "ę"]
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "миНУта"
+    },
+    "translations": {
+      "ru": "минута"
+    }
+  },
+  "nadzieja": {
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Mam nadzieję, że przyjdziesz.",
+        "ru": "Надеюсь, что ты придёшь.",
+        "ru_transcription": "мам надЗЕем жэ пшыйдЗЕшь."
+      },
+      {
+        "pl": "Z nadzieją czekam.",
+        "ru": "Жду с надеждой.",
+        "ru_transcription": "з надЗЕём чэкам."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "nadzieje",
+        "dative": "nadziejom",
+        "genitive": "nadziei",
+        "instrumental": "nadziejami",
+        "locative": "nadziejach",
+        "nominative": "nadzieje",
+        "vocative": "nadzieje"
+      },
+      "singular": {
+        "accusative": "nadzieję",
+        "dative": "nadziei",
+        "genitive": "nadziei",
+        "instrumental": "nadzieją",
+        "locative": "nadziei",
+        "nominative": "nadzieja",
+        "vocative": "nadziejo"
+      }
+    },
+    "lemma": "nadzieja",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [
+      {
+        "pl": "mieć nadzieję",
+        "ru": "надеяться"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "надЗЕя"
+    },
+    "translations": {
+      "ru": "надежда"
+    }
+  },
+  "nietolerancja": {
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Nietolerancja laktozy.",
+        "ru": "Непереносимость лактозы.",
+        "ru_transcription": "нЭтолЭранця лактОзы."
+      },
+      {
+        "pl": "Mam nietolerancję glutenu.",
+        "ru": "У меня непереносимость глютена.",
+        "ru_transcription": "мам нЭтолЭранцьем глутЭну."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "nietolerancje",
+        "dative": "nietolerancjom",
+        "genitive": "nietolerancji",
+        "instrumental": "nietolerancjami",
+        "locative": "nietolerancjach",
+        "nominative": "nietolerancje",
+        "vocative": "nietolerancje"
+      },
+      "singular": {
+        "accusative": "nietolerancję",
+        "dative": "nietolerancji",
+        "genitive": "nietolerancji",
+        "instrumental": "nietolerancją",
+        "locative": "nietolerancji",
+        "nominative": "nietolerancja",
+        "vocative": "nietolerancjo"
+      }
+    },
+    "lemma": "nietolerancja",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "нЭтолЭранця"
+    },
+    "translations": {
+      "ru": "непереносимость"
+    }
+  },
+  "odrobina": {
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Odrobina soli.",
+        "ru": "Чуточка соли.",
+        "ru_transcription": "одробИна соли."
+      },
+      {
+        "pl": "Tylko odrobina cukru.",
+        "ru": "Только чуточка сахара.",
+        "ru_transcription": "тылько одробИна цукру."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "odrobiny",
+        "dative": "odrobinom",
+        "genitive": "odrobin",
+        "instrumental": "odrobinami",
+        "locative": "odrobinach",
+        "nominative": "odrobiny",
+        "vocative": "odrobiny"
+      },
+      "singular": {
+        "accusative": "odrobinę",
+        "dative": "odrobinie",
+        "genitive": "odrobiny",
+        "instrumental": "odrobiną",
+        "locative": "odrobinie",
+        "nominative": "odrobina",
+        "vocative": "odrobino"
+      }
+    },
+    "lemma": "odrobina",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "одробИна"
+    },
+    "translations": {
+      "ru": "чуточка"
+    }
   },
   "okno": {
-    "lemma": "okno",
-    "part_of_speech": "noun",
-    "translations": { "ru": "окно" },
-    "pronunciation": { 
-      "ru_transcription": "окно",
-      "key_forms": []
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Otwórz okno, proszę.",
+        "ru": "Открой окно, пожалуйста.",
+        "ru_transcription": "отвуж окно прошэм."
+      },
+      {
+        "pl": "Stolik przy oknie.",
+        "ru": "Столик у окна.",
+        "ru_transcription": "столик пшы окьнэ."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "okna",
+        "dative": "oknom",
+        "genitive": "okien",
+        "instrumental": "oknami",
+        "locative": "oknach",
+        "nominative": "okna",
+        "vocative": "okna"
+      },
+      "singular": {
+        "accusative": "okno",
+        "dative": "oknu",
+        "genitive": "okna",
+        "instrumental": "oknem",
+        "locative": "oknie",
+        "nominative": "okno",
+        "vocative": "okno"
+      }
     },
+    "lemma": "okno",
     "morphology": {
       "gender": "neuter"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "okno",
-        "genitive": "okna",
-        "dative": "oknu",
-        "accusative": "okno",
-        "instrumental": "oknem",
-        "locative": "oknie",
-        "vocative": "okno"
-      },
-      "plural": {
-        "nominative": "okna",
-        "genitive": "okien",
-        "dative": "oknom",
-        "accusative": "okna",
-        "instrumental": "oknami",
-        "locative": "oknach",
-        "vocative": "okna"
-      }
-    },
-    "examples": [
-      { "pl": "Otwórz okno, proszę.", "ru": "Открой окно, пожалуйста.", "ru_transcription": "отвуж окно прошэм." },
-      { "pl": "Stolik przy oknie.", "ru": "Столик у окна.", "ru_transcription": "столик пшы окьнэ." }
-    ],
+    "part_of_speech": "noun",
     "phrases_and_idioms": [
-      { "pl": "przy oknie", "ru": "у окна" }
+      {
+        "pl": "przy oknie",
+        "ru": "у окна"
+      }
     ],
-    "applied_rules": []
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "окно"
+    },
+    "translations": {
+      "ru": "окно"
+    }
   },
   "opinia": {
-    "lemma": "opinia",
-    "part_of_speech": "noun",
-    "translations": { "ru": "мнение" },
-    "pronunciation": { 
-      "ru_transcription": "опиНЯ",
-      "key_forms": []
-    },
-    "morphology": {
-      "gender": "feminine"
-    },
-    "inflection": {
-      "singular": {
-        "nominative": "opinia",
-        "genitive": "opinii",
-        "dative": "opinii",
-        "accusative": "opinię",
-        "instrumental": "opinią",
-        "locative": "opinii",
-        "vocative": "opinio"
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Jaka jest twoja opinia?",
+        "ru": "Какое твоё мнение?",
+        "ru_transcription": "яка ест твоя опиНЯ?"
       },
+      {
+        "pl": "Mam dobrą opinię o tej restauracji.",
+        "ru": "У меня хорошее мнение об этом ресторане.",
+        "ru_transcription": "мам добрОм опиньем о тэй рэстауРАцьи."
+      }
+    ],
+    "inflection": {
       "plural": {
-        "nominative": "opinie",
-        "genitive": "opinii",
-        "dative": "opiniom",
         "accusative": "opinie",
+        "dative": "opiniom",
+        "genitive": "opinii",
         "instrumental": "opiniami",
         "locative": "opiniach",
+        "nominative": "opinie",
         "vocative": "opinie"
+      },
+      "singular": {
+        "accusative": "opinię",
+        "dative": "opinii",
+        "genitive": "opinii",
+        "instrumental": "opinią",
+        "locative": "opinii",
+        "nominative": "opinia",
+        "vocative": "opinio"
       }
     },
-    "examples": [
-      { "pl": "Jaka jest twoja opinia?", "ru": "Какое твоё мнение?", "ru_transcription": "яка ест твоя опиНЯ?" },
-      { "pl": "Mam dobrą opinię o tej restauracji.", "ru": "У меня хорошее мнение об этом ресторане.", "ru_transcription": "мам добрОм опиньем о тэй рэстауРАцьи." }
-    ],
-    "phrases_and_idioms": [],
-    "applied_rules": ["ą", "ę"]
-  },
-  "nadzieja": {
-    "lemma": "nadzieja",
-    "part_of_speech": "noun",
-    "translations": { "ru": "надежда" },
-    "pronunciation": { 
-      "ru_transcription": "надЗЕя",
-      "key_forms": []
-    },
+    "lemma": "opinia",
     "morphology": {
       "gender": "feminine"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "nadzieja",
-        "genitive": "nadziei",
-        "dative": "nadziei",
-        "accusative": "nadzieję",
-        "instrumental": "nadzieją",
-        "locative": "nadziei",
-        "vocative": "nadziejo"
-      },
-      "plural": {
-        "nominative": "nadzieje",
-        "genitive": "nadziei",
-        "dative": "nadziejom",
-        "accusative": "nadzieje",
-        "instrumental": "nadziejami",
-        "locative": "nadziejach",
-        "vocative": "nadzieje"
-      }
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "опиНЯ"
     },
-    "examples": [
-      { "pl": "Mam nadzieję, że przyjdziesz.", "ru": "Надеюсь, что ты придёшь.", "ru_transcription": "мам надЗЕем жэ пшыйдЗЕшь." },
-      { "pl": "Z nadzieją czekam.", "ru": "Жду с надеждой.", "ru_transcription": "з надЗЕём чэкам." }
-    ],
-    "phrases_and_idioms": [
-      { "pl": "mieć nadzieję", "ru": "надеяться" }
-    ],
-    "applied_rules": ["ą", "ę"]
+    "translations": {
+      "ru": "мнение"
+    }
   },
   "woda": {
-    "lemma": "woda",
-    "part_of_speech": "noun",
-    "translations": { "ru": "вода" },
-    "pronunciation": { 
-      "ru_transcription": "вода",
-      "key_forms": []
+    "applied_rules": [
+      "ó",
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Poproszę wodę.",
+        "ru": "Воды, пожалуйста.",
+        "ru_transcription": "попрошЭм водЭм."
+      },
+      {
+        "pl": "Woda gazowana czy niegazowana?",
+        "ru": "Вода газированная или негазированная?",
+        "ru_transcription": "вода газована чы нЭгазована?"
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "wody",
+        "dative": "wodom",
+        "genitive": "wód",
+        "instrumental": "wodami",
+        "locative": "wodach",
+        "nominative": "wody",
+        "vocative": "wody"
+      },
+      "singular": {
+        "accusative": "wodę",
+        "dative": "wodzie",
+        "genitive": "wody",
+        "instrumental": "wodą",
+        "locative": "wodzie",
+        "nominative": "woda",
+        "vocative": "wodo"
+      }
     },
+    "lemma": "woda",
     "morphology": {
       "gender": "feminine"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "woda",
-        "genitive": "wody",
-        "dative": "wodzie",
-        "accusative": "wodę",
-        "instrumental": "wodą",
-        "locative": "wodzie",
-        "vocative": "wodo"
-      },
-      "plural": {
-        "nominative": "wody",
-        "genitive": "wód",
-        "dative": "wodom",
-        "accusative": "wody",
-        "instrumental": "wodami",
-        "locative": "wodach",
-        "vocative": "wody"
-      }
-    },
-    "examples": [
-      { "pl": "Poproszę wodę.", "ru": "Воды, пожалуйста.", "ru_transcription": "попрошЭм водЭм." },
-      { "pl": "Woda gazowana czy niegazowana?", "ru": "Вода газированная или негазированная?", "ru_transcription": "вода газована чы нЭгазована?" }
-    ],
+    "part_of_speech": "noun",
     "phrases_and_idioms": [
-      { "pl": "woda mineralna", "ru": "минеральная вода" }
+      {
+        "pl": "woda mineralna",
+        "ru": "минеральная вода"
+      }
     ],
-    "applied_rules": ["ó", "ą", "ę"]
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "вода"
+    },
+    "translations": {
+      "ru": "вода"
+    }
   }
 }

--- a/data/dictionary/nouns/restaurant.json
+++ b/data/dictionary/nouns/restaurant.json
@@ -1,274 +1,1172 @@
 {
-  "kawiarnia": {
-    "lemma": "kawiarnia",
-    "part_of_speech": "noun",
-    "translations": { "ru": "кофейня" },
-    "pronunciation": { 
-      "ru_transcription": "кавярНЯ",
-      "key_forms": []
+  "deser": {
+    "applied_rules": [
+      "ó"
+    ],
+    "examples": [
+      {
+        "pl": "Na deser chcę lody.",
+        "ru": "На десерт хочу мороженое.",
+        "ru_transcription": "на дэсэр хцэм льоды."
+      },
+      {
+        "pl": "Jaki deser Pan poleca?",
+        "ru": "Какой десерт Вы рекомендуете?",
+        "ru_transcription": "яки дэсэр пан полЭца?"
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "desery",
+        "dative": "deserom",
+        "genitive": "deserów",
+        "instrumental": "deserami",
+        "locative": "deserach",
+        "nominative": "desery",
+        "vocative": "desery"
+      },
+      "singular": {
+        "accusative": "deser",
+        "dative": "deserowi",
+        "genitive": "deseru",
+        "instrumental": "deserem",
+        "locative": "deserze",
+        "nominative": "deser",
+        "vocative": "deserze"
+      }
     },
+    "lemma": "deser",
+    "morphology": {
+      "gender": "masculine_inanimate"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "дэсэр"
+    },
+    "translations": {
+      "ru": "десерт"
+    }
+  },
+  "kawiarnia": {
+    "applied_rules": [
+      "ą",
+      "ę",
+      "ń"
+    ],
+    "examples": [
+      {
+        "pl": "Idziemy do kawiarni.",
+        "ru": "Идём в кофейню.",
+        "ru_transcription": "идЗЕмы до кавярни."
+      },
+      {
+        "pl": "Ta kawiarnia ma dobrą kawę.",
+        "ru": "В этой кофейне хороший кофе.",
+        "ru_transcription": "та кавярНЯ ма добрОм кавэм."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "kawiarnie",
+        "dative": "kawiarniom",
+        "genitive": "kawiarń",
+        "instrumental": "kawiarniami",
+        "locative": "kawiarniach",
+        "nominative": "kawiarnie",
+        "vocative": "kawiarnie"
+      },
+      "singular": {
+        "accusative": "kawiarnię",
+        "dative": "kawiarni",
+        "genitive": "kawiarni",
+        "instrumental": "kawiarnią",
+        "locative": "kawiarni",
+        "nominative": "kawiarnia",
+        "vocative": "kawiarniu"
+      }
+    },
+    "lemma": "kawiarnia",
     "morphology": {
       "gender": "feminine"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "kawiarnia",
-        "genitive": "kawiarni",
-        "dative": "kawiarni",
-        "accusative": "kawiarnię",
-        "instrumental": "kawiarnią",
-        "locative": "kawiarni",
-        "vocative": "kawiarniu"
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "кавярНЯ"
+    },
+    "translations": {
+      "ru": "кофейня"
+    }
+  },
+  "krem": {
+    "applied_rules": [
+      "ó"
+    ],
+    "examples": [
+      {
+        "pl": "Krem czekoladowy.",
+        "ru": "Шоколадный крем.",
+        "ru_transcription": "крЭм чэколадОвы."
       },
+      {
+        "pl": "Ciasto z kremem.",
+        "ru": "Пирожное с кремом.",
+        "ru_transcription": "цЯсто з крЭмэм."
+      }
+    ],
+    "inflection": {
       "plural": {
-        "nominative": "kawiarnie",
-        "genitive": "kawiarń",
-        "dative": "kawiarniom",
-        "accusative": "kawiarnie",
-        "instrumental": "kawiarniami",
-        "locative": "kawiarniach",
-        "vocative": "kawiarnie"
+        "accusative": "kremy",
+        "dative": "kremom",
+        "genitive": "kremów",
+        "instrumental": "kremami",
+        "locative": "kremach",
+        "nominative": "kremy",
+        "vocative": "kremy"
+      },
+      "singular": {
+        "accusative": "krem",
+        "dative": "kremowi",
+        "genitive": "kremu",
+        "instrumental": "kremem",
+        "locative": "kremie",
+        "nominative": "krem",
+        "vocative": "kremie"
       }
     },
-    "examples": [
-      { "pl": "Idziemy do kawiarni.", "ru": "Идём в кофейню.", "ru_transcription": "идЗЕмы до кавярни." },
-      { "pl": "Ta kawiarnia ma dobrą kawę.", "ru": "В этой кофейне хороший кофе.", "ru_transcription": "та кавярНЯ ма добрОм кавэм." }
-    ],
+    "lemma": "krem",
+    "morphology": {
+      "gender": "masculine_inanimate"
+    },
+    "part_of_speech": "noun",
     "phrases_and_idioms": [],
-    "applied_rules": ["ą", "ę", "ń"]
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "крЭм"
+    },
+    "translations": {
+      "ru": "крем"
+    }
+  },
+  "laktoza": {
+    "applied_rules": [
+      "ę",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Mam nietolerancję laktozy.",
+        "ru": "У меня непереносимость лактозы.",
+        "ru_transcription": "мам нЭтолЭранцьем лактОзы."
+      },
+      {
+        "pl": "Produkt bez laktozy.",
+        "ru": "Продукт без лактозы.",
+        "ru_transcription": "продукт бэз лактОзы."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "laktozy",
+        "dative": "laktozom",
+        "genitive": "laktoz",
+        "instrumental": "laktozami",
+        "locative": "laktozach",
+        "nominative": "laktozy",
+        "vocative": "laktozy"
+      },
+      "singular": {
+        "accusative": "laktozę",
+        "dative": "laktozie",
+        "genitive": "laktozy",
+        "instrumental": "laktozą",
+        "locative": "laktozie",
+        "nominative": "laktoza",
+        "vocative": "laktozo"
+      }
+    },
+    "lemma": "laktoza",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "лактОза"
+    },
+    "translations": {
+      "ru": "лактоза"
+    }
   },
   "menu": {
-    "lemma": "menu",
-    "part_of_speech": "noun",
-    "translations": { "ru": "меню" },
-    "pronunciation": { 
-      "ru_transcription": "мэню",
-      "key_forms": []
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Poproszę menu.",
+        "ru": "Меню, пожалуйста.",
+        "ru_transcription": "попрошЭм мэню."
+      },
+      {
+        "pl": "Czy mają menu w języku polskim?",
+        "ru": "У них есть меню на польском языке?",
+        "ru_transcription": "чы маём мэню в ЕнзЫку польским?"
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "menu",
+        "dative": "menu",
+        "genitive": "menu",
+        "instrumental": "menu",
+        "locative": "menu",
+        "nominative": "menu",
+        "vocative": "menu"
+      },
+      "singular": {
+        "accusative": "menu",
+        "dative": "menu",
+        "genitive": "menu",
+        "instrumental": "menu",
+        "locative": "menu",
+        "nominative": "menu",
+        "vocative": "menu"
+      }
     },
+    "lemma": "menu",
     "morphology": {
       "gender": "neuter"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "menu",
-        "genitive": "menu",
-        "dative": "menu",
-        "accusative": "menu",
-        "instrumental": "menu",
-        "locative": "menu",
-        "vocative": "menu"
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "мэню"
+    },
+    "translations": {
+      "ru": "меню"
+    }
+  },
+  "mleko": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Kawa z mlekiem.",
+        "ru": "Кофе с молоком.",
+        "ru_transcription": "кава з млЭкьем."
       },
+      {
+        "pl": "Mleko kokosowe.",
+        "ru": "Кокосовое молоко.",
+        "ru_transcription": "млЭко кокосОвэ."
+      }
+    ],
+    "inflection": {
       "plural": {
-        "nominative": "menu",
-        "genitive": "menu",
-        "dative": "menu",
-        "accusative": "menu",
-        "instrumental": "menu",
-        "locative": "menu",
-        "vocative": "menu"
+        "accusative": "mleka",
+        "dative": "mlekom",
+        "genitive": "mlek",
+        "instrumental": "mlekami",
+        "locative": "mlekach",
+        "nominative": "mleka",
+        "vocative": "mleka"
+      },
+      "singular": {
+        "accusative": "mleko",
+        "dative": "mleku",
+        "genitive": "mleka",
+        "instrumental": "mlekiem",
+        "locative": "mleku",
+        "nominative": "mleko",
+        "vocative": "mleko"
       }
     },
-    "examples": [
-      { "pl": "Poproszę menu.", "ru": "Меню, пожалуйста.", "ru_transcription": "попрошЭм мэню." },
-      { "pl": "Czy mają menu w języku polskim?", "ru": "У них есть меню на польском языке?", "ru_transcription": "чы маём мэню в ЕнзЫку польским?" }
-    ],
-    "phrases_and_idioms": [],
-    "applied_rules": []
-  },
-  "deser": {
-    "lemma": "deser",
-    "part_of_speech": "noun",
-    "translations": { "ru": "десерт" },
-    "pronunciation": { 
-      "ru_transcription": "дэсэр",
-      "key_forms": []
+    "lemma": "mleko",
+    "morphology": {
+      "gender": "neuter"
     },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "млЭко"
+    },
+    "translations": {
+      "ru": "молоко"
+    }
+  },
+  "napiwek": {
+    "applied_rules": [
+      "ó"
+    ],
+    "examples": [
+      {
+        "pl": "Zostawiam napiwek.",
+        "ru": "Оставляю чаевые.",
+        "ru_transcription": "зоставЯм напИвэк."
+      },
+      {
+        "pl": "Napiwek już jest wliczony.",
+        "ru": "Чаевые уже включены.",
+        "ru_transcription": "напИвэк юж ест влИчоны."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "napiwki",
+        "dative": "napiwkom",
+        "genitive": "napiwków",
+        "instrumental": "napiwkami",
+        "locative": "napiwkach",
+        "nominative": "napiwki",
+        "vocative": "napiwki"
+      },
+      "singular": {
+        "accusative": "napiwek",
+        "dative": "napiwkowi",
+        "genitive": "napiwku",
+        "instrumental": "napiwkiem",
+        "locative": "napiwku",
+        "nominative": "napiwek",
+        "vocative": "napiwku"
+      }
+    },
+    "lemma": "napiwek",
     "morphology": {
       "gender": "masculine_inanimate"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "deser",
-        "genitive": "deseru",
-        "dative": "deserowi",
-        "accusative": "deser",
-        "instrumental": "deserem",
-        "locative": "deserze",
-        "vocative": "deserze"
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [
+      {
+        "pl": "zostawiać napiwek",
+        "ru": "оставлять чаевые"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "напИвэк"
+    },
+    "translations": {
+      "ru": "чаевые"
+    }
+  },
+  "parmezan": {
+    "applied_rules": [
+      "ó"
+    ],
+    "examples": [
+      {
+        "pl": "Risotto z parmezanem.",
+        "ru": "Ризотто с пармезаном.",
+        "ru_transcription": "ризОтто з пармЭзанэм."
       },
+      {
+        "pl": "Posypię parmezanem.",
+        "ru": "Посыплю пармезаном.",
+        "ru_transcription": "посыпЭм пармЭзанэм."
+      }
+    ],
+    "inflection": {
       "plural": {
-        "nominative": "desery",
-        "genitive": "deserów",
-        "dative": "deserom",
-        "accusative": "desery",
-        "instrumental": "deserami",
-        "locative": "deserach",
-        "vocative": "desery"
+        "accusative": "parmezany",
+        "dative": "parmezanom",
+        "genitive": "parmezanów",
+        "instrumental": "parmezanami",
+        "locative": "parmezanach",
+        "nominative": "parmezany",
+        "vocative": "parmezany"
+      },
+      "singular": {
+        "accusative": "parmezan",
+        "dative": "parmezanowi",
+        "genitive": "parmezanu",
+        "instrumental": "parmezanem",
+        "locative": "parmezanie",
+        "nominative": "parmezan",
+        "vocative": "parmezanie"
       }
     },
-    "examples": [
-      { "pl": "Na deser chcę lody.", "ru": "На десерт хочу мороженое.", "ru_transcription": "на дэсэр хцэм льоды." },
-      { "pl": "Jaki deser Pan poleca?", "ru": "Какой десерт Вы рекомендуете?", "ru_transcription": "яки дэсэр пан полЭца?" }
-    ],
-    "phrases_and_idioms": [],
-    "applied_rules": ["ó"]
-  },
-  "zupa": {
-    "lemma": "zupa",
-    "part_of_speech": "noun",
-    "translations": { "ru": "суп" },
-    "pronunciation": { 
-      "ru_transcription": "зупа",
-      "key_forms": []
+    "lemma": "parmezan",
+    "morphology": {
+      "gender": "masculine_inanimate"
     },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "пармЭзан"
+    },
+    "translations": {
+      "ru": "пармезан"
+    }
+  },
+  "picie": {
+    "applied_rules": [
+      "ć"
+    ],
+    "examples": [
+      {
+        "pl": "Co do picia?",
+        "ru": "Что будете пить?",
+        "ru_transcription": "цо до пИча?"
+      },
+      {
+        "pl": "Menu picia.",
+        "ru": "Меню напитков.",
+        "ru_transcription": "мэню пИча."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "picia",
+        "dative": "piciom",
+        "genitive": "pić",
+        "instrumental": "piciami",
+        "locative": "piciach",
+        "nominative": "picia",
+        "vocative": "picia"
+      },
+      "singular": {
+        "accusative": "picie",
+        "dative": "piciu",
+        "genitive": "picia",
+        "instrumental": "piciem",
+        "locative": "piciu",
+        "nominative": "picie",
+        "vocative": "picie"
+      }
+    },
+    "lemma": "picie",
+    "morphology": {
+      "gender": "neuter"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "пИчэ"
+    },
+    "translations": {
+      "ru": "питьё"
+    }
+  },
+  "pieczywo": {
+    "applied_rules": [
+      "cz"
+    ],
+    "examples": [
+      {
+        "pl": "Świeże pieczywo.",
+        "ru": "Свежий хлеб.",
+        "ru_transcription": "шьвЕжэ пЕчыво."
+      },
+      {
+        "pl": "Koszyk z pieczywem.",
+        "ru": "Корзинка с хлебом.",
+        "ru_transcription": "кошЫк з пЕчывэм."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "pieczywa",
+        "dative": "pieczywom",
+        "genitive": "pieczyw",
+        "instrumental": "pieczywami",
+        "locative": "pieczywach",
+        "nominative": "pieczywa",
+        "vocative": "pieczywa"
+      },
+      "singular": {
+        "accusative": "pieczywo",
+        "dative": "pieczywu",
+        "genitive": "pieczywa",
+        "instrumental": "pieczywem",
+        "locative": "pieczywie",
+        "nominative": "pieczywo",
+        "vocative": "pieczywo"
+      }
+    },
+    "lemma": "pieczywo",
+    "morphology": {
+      "gender": "neuter"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "пЕчыво"
+    },
+    "translations": {
+      "ru": "хлебобулочные изделия"
+    }
+  },
+  "rachunek": {
+    "applied_rules": [
+      "ó"
+    ],
+    "examples": [
+      {
+        "pl": "Poproszę rachunek.",
+        "ru": "Счёт, пожалуйста.",
+        "ru_transcription": "попрошЭм рахунэк."
+      },
+      {
+        "pl": "Rachunek wynosi 50 złotych.",
+        "ru": "Счёт составляет 50 злотых.",
+        "ru_transcription": "рахунэк выноси 50 зВОтых."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "rachunki",
+        "dative": "rachunkom",
+        "genitive": "rachunków",
+        "instrumental": "rachunkami",
+        "locative": "rachunkach",
+        "nominative": "rachunki",
+        "vocative": "rachunki"
+      },
+      "singular": {
+        "accusative": "rachunek",
+        "dative": "rachunkowi",
+        "genitive": "rachunku",
+        "instrumental": "rachunkiem",
+        "locative": "rachunku",
+        "nominative": "rachunek",
+        "vocative": "rachunku"
+      }
+    },
+    "lemma": "rachunek",
+    "morphology": {
+      "gender": "masculine_inanimate"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [
+      {
+        "pl": "płacić rachunek",
+        "ru": "оплачивать счёт"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "рахунэк"
+    },
+    "translations": {
+      "ru": "счёт"
+    }
+  },
+  "rewelacja": {
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "To prawdziwa rewelacja!",
+        "ru": "Это настоящая сенсация!",
+        "ru_transcription": "то правдзИва рэвэЛЯця!"
+      },
+      {
+        "pl": "Smakowa rewelacja.",
+        "ru": "Вкусовая сенсация.",
+        "ru_transcription": "смакОва рэвэЛЯця."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "rewelacje",
+        "dative": "rewelacjom",
+        "genitive": "rewelacji",
+        "instrumental": "rewelacjami",
+        "locative": "rewelacjach",
+        "nominative": "rewelacje",
+        "vocative": "rewelacje"
+      },
+      "singular": {
+        "accusative": "rewelację",
+        "dative": "rewelacji",
+        "genitive": "rewelacji",
+        "instrumental": "rewelacją",
+        "locative": "rewelacji",
+        "nominative": "rewelacja",
+        "vocative": "rewelacjo"
+      }
+    },
+    "lemma": "rewelacja",
     "morphology": {
       "gender": "feminine"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "zupa",
-        "genitive": "zupy",
-        "dative": "zupie",
-        "accusative": "zupę",
-        "instrumental": "zupą",
-        "locative": "zupie",
-        "vocative": "zupo"
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "рэвэЛЯця"
+    },
+    "translations": {
+      "ru": "сенсация"
+    }
+  },
+  "rezerwacja": {
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Mam rezerwację na nazwisko Kowalski.",
+        "ru": "У меня бронь на фамилию Ковальский.",
+        "ru_transcription": "мам рэзэрВАцем на назВИско коваЛЬски."
       },
+      {
+        "pl": "Czy potrzebna rezerwacja?",
+        "ru": "Нужна ли бронь?",
+        "ru_transcription": "чы потшЭбна рэзэрВАця?"
+      }
+    ],
+    "inflection": {
       "plural": {
-        "nominative": "zupy",
-        "genitive": "zup",
-        "dative": "zupom",
-        "accusative": "zupy",
-        "instrumental": "zupami",
-        "locative": "zupach",
-        "vocative": "zupy"
+        "accusative": "rezerwacje",
+        "dative": "rezerwacjom",
+        "genitive": "rezerwacji",
+        "instrumental": "rezerwacjami",
+        "locative": "rezerwacjach",
+        "nominative": "rezerwacje",
+        "vocative": "rezerwacje"
+      },
+      "singular": {
+        "accusative": "rezerwację",
+        "dative": "rezerwacji",
+        "genitive": "rezerwacji",
+        "instrumental": "rezerwacją",
+        "locative": "rezerwacji",
+        "nominative": "rezerwacja",
+        "vocative": "rezerwacjo"
       }
     },
-    "examples": [
-      { "pl": "Zamawiam zupę pomidorową.", "ru": "Заказываю томатный суп.", "ru_transcription": "замаВЯм зупЭм помидорОвОм." },
-      { "pl": "Ta zupa jest bardzo smaczna.", "ru": "Этот суп очень вкусный.", "ru_transcription": "та зупа ест бардзо смачна." }
-    ],
+    "lemma": "rezerwacja",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
     "phrases_and_idioms": [],
-    "applied_rules": ["ą", "ę"]
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "рэзэрВАця"
+    },
+    "translations": {
+      "ru": "бронирование"
+    }
+  },
+  "risotto": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Risotto z grzybami.",
+        "ru": "Ризотто с грибами.",
+        "ru_transcription": "ризОтто з гжыбами."
+      },
+      {
+        "pl": "Pyszne risotto!",
+        "ru": "Вкусное ризотто!",
+        "ru_transcription": "пышнэ ризОтто!"
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "risotto",
+        "dative": "risotto",
+        "genitive": "risotto",
+        "instrumental": "risotto",
+        "locative": "risotto",
+        "nominative": "risotto",
+        "vocative": "risotto"
+      },
+      "singular": {
+        "accusative": "risotto",
+        "dative": "risotto",
+        "genitive": "risotto",
+        "instrumental": "risotto",
+        "locative": "risotto",
+        "nominative": "risotto",
+        "vocative": "risotto"
+      }
+    },
+    "lemma": "risotto",
+    "morphology": {
+      "gender": "neuter"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "ризОтто"
+    },
+    "translations": {
+      "ru": "ризотто"
+    }
+  },
+  "ser": {
+    "applied_rules": [
+      "ó"
+    ],
+    "examples": [
+      {
+        "pl": "Kawałek sera.",
+        "ru": "Кусочек сыра.",
+        "ru_transcription": "каваВЭк сэра."
+      },
+      {
+        "pl": "Jakiego sera Pan sobie życzy?",
+        "ru": "Какой сыр Вы желаете?",
+        "ru_transcription": "якЕго сэра пан собЕ жЫчы?"
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "sery",
+        "dative": "serom",
+        "genitive": "serów",
+        "instrumental": "serami",
+        "locative": "serach",
+        "nominative": "sery",
+        "vocative": "sery"
+      },
+      "singular": {
+        "accusative": "ser",
+        "dative": "serowi",
+        "genitive": "sera",
+        "instrumental": "serem",
+        "locative": "serze",
+        "nominative": "ser",
+        "vocative": "serze"
+      }
+    },
+    "lemma": "ser",
+    "morphology": {
+      "gender": "masculine_inanimate"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "сэр"
+    },
+    "translations": {
+      "ru": "сыр"
+    }
+  },
+  "specjalność": {
+    "applied_rules": [
+      "ś",
+      "ć"
+    ],
+    "examples": [
+      {
+        "pl": "Specjalność zakładu.",
+        "ru": "Фирменное блюдо заведения.",
+        "ru_transcription": "спэцьяЛЬношч закВАду."
+      },
+      {
+        "pl": "Jaka jest wasza specjalność?",
+        "ru": "Какая у вас специальность?",
+        "ru_transcription": "яка ест ваша спэцьяЛЬношч?"
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "specjalności",
+        "dative": "specjalnościom",
+        "genitive": "specjalności",
+        "instrumental": "specjalnościami",
+        "locative": "specjalnościach",
+        "nominative": "specjalności",
+        "vocative": "specjalności"
+      },
+      "singular": {
+        "accusative": "specjalność",
+        "dative": "specjalności",
+        "genitive": "specjalności",
+        "instrumental": "specjalnością",
+        "locative": "specjalności",
+        "nominative": "specjalność",
+        "vocative": "specjalności"
+      }
+    },
+    "lemma": "specjalność",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "спэцьяЛЬношч"
+    },
+    "translations": {
+      "ru": "специальность"
+    }
   },
   "stolik": {
-    "lemma": "stolik",
-    "part_of_speech": "noun",
-    "translations": { "ru": "столик" },
-    "pronunciation": { 
-      "ru_transcription": "столик",
-      "key_forms": []
-    },
-    "morphology": {
-      "gender": "masculine_inanimate"
-    },
-    "inflection": {
-      "singular": {
-        "nominative": "stolik",
-        "genitive": "stolika",
-        "dative": "stolikowi",
-        "accusative": "stolik",
-        "instrumental": "stolikiem",
-        "locative": "stoliku",
-        "vocative": "stoliku"
+    "applied_rules": [
+      "ó"
+    ],
+    "examples": [
+      {
+        "pl": "Rezerwuję stolik na dwóch.",
+        "ru": "Бронирую столик на двоих.",
+        "ru_transcription": "рэзэрвуЭм столик на двух."
       },
+      {
+        "pl": "Czy jest wolny stolik?",
+        "ru": "Есть свободный столик?",
+        "ru_transcription": "чы ест вольны столик?"
+      }
+    ],
+    "inflection": {
       "plural": {
-        "nominative": "stoliki",
-        "genitive": "stolików",
-        "dative": "stolikom",
         "accusative": "stoliki",
+        "dative": "stolikom",
+        "genitive": "stolików",
         "instrumental": "stolikami",
         "locative": "stolikach",
+        "nominative": "stoliki",
         "vocative": "stoliki"
+      },
+      "singular": {
+        "accusative": "stolik",
+        "dative": "stolikowi",
+        "genitive": "stolika",
+        "instrumental": "stolikiem",
+        "locative": "stoliku",
+        "nominative": "stolik",
+        "vocative": "stoliku"
       }
     },
-    "examples": [
-      { "pl": "Rezerwuję stolik na dwóch.", "ru": "Бронирую столик на двоих.", "ru_transcription": "рэзэрвуЭм столик на двух." },
-      { "pl": "Czy jest wolny stolik?", "ru": "Есть свободный столик?", "ru_transcription": "чы ест вольны столик?" }
-    ],
-    "phrases_and_idioms": [
-      { "pl": "rezerwować stolik", "ru": "бронировать столик" }
-    ],
-    "applied_rules": ["ó"]
-  },
-  "rachunek": {
-    "lemma": "rachunek",
-    "part_of_speech": "noun",
-    "translations": { "ru": "счёт" },
-    "pronunciation": { 
-      "ru_transcription": "рахунэк",
-      "key_forms": []
-    },
+    "lemma": "stolik",
     "morphology": {
       "gender": "masculine_inanimate"
     },
-    "inflection": {
-      "singular": {
-        "nominative": "rachunek",
-        "genitive": "rachunku",
-        "dative": "rachunkowi",
-        "accusative": "rachunek",
-        "instrumental": "rachunkiem",
-        "locative": "rachunku",
-        "vocative": "rachunku"
-      },
-      "plural": {
-        "nominative": "rachunki",
-        "genitive": "rachunków",
-        "dative": "rachunkom",
-        "accusative": "rachunki",
-        "instrumental": "rachunkami",
-        "locative": "rachunkach",
-        "vocative": "rachunki"
-      }
-    },
-    "examples": [
-      { "pl": "Poproszę rachunek.", "ru": "Счёт, пожалуйста.", "ru_transcription": "попрошЭм рахунэк." },
-      { "pl": "Rachunek wynosi 50 złotych.", "ru": "Счёт составляет 50 злотых.", "ru_transcription": "рахунэк выноси 50 зВОтых." }
-    ],
-    "phrases_and_idioms": [
-      { "pl": "płacić rachunek", "ru": "оплачивать счёт" }
-    ],
-    "applied_rules": ["ó"]
-  },
-  "napiwek": {
-    "lemma": "napiwek",
     "part_of_speech": "noun",
-    "translations": { "ru": "чаевые" },
-    "pronunciation": { 
-      "ru_transcription": "напИвэк",
-      "key_forms": []
+    "phrases_and_idioms": [
+      {
+        "pl": "rezerwować stolik",
+        "ru": "бронировать столик"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "столик"
     },
-    "morphology": {
-      "gender": "masculine_inanimate"
-    },
-    "inflection": {
-      "singular": {
-        "nominative": "napiwek",
-        "genitive": "napiwku",
-        "dative": "napiwkowi",
-        "accusative": "napiwek",
-        "instrumental": "napiwkiem",
-        "locative": "napiwku",
-        "vocative": "napiwku"
+    "translations": {
+      "ru": "столик"
+    }
+  },
+  "tarta": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Tarta czekoladowa.",
+        "ru": "Шоколадный торт.",
+        "ru_transcription": "тАрта чэколадОва."
       },
+      {
+        "pl": "Kawałek tarty.",
+        "ru": "Кусочек торта.",
+        "ru_transcription": "каваВЭк тАрты."
+      }
+    ],
+    "inflection": {
       "plural": {
-        "nominative": "napiwki",
-        "genitive": "napiwków",
-        "dative": "napiwkom",
-        "accusative": "napiwki",
-        "instrumental": "napiwkami",
-        "locative": "napiwkach",
-        "vocative": "napiwki"
+        "accusative": "tarty",
+        "dative": "tartom",
+        "genitive": "tart",
+        "instrumental": "tartami",
+        "locative": "tartach",
+        "nominative": "tarty",
+        "vocative": "tarty"
+      },
+      "singular": {
+        "accusative": "tartę",
+        "dative": "tarcie",
+        "genitive": "tarty",
+        "instrumental": "tartą",
+        "locative": "tarcie",
+        "nominative": "tarta",
+        "vocative": "tarto"
       }
     },
+    "lemma": "tarta",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "тАрта"
+    },
+    "translations": {
+      "ru": "торт"
+    }
+  },
+  "wersja": {
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
     "examples": [
-      { "pl": "Zostawiam napiwek.", "ru": "Оставляю чаевые.", "ru_transcription": "зоставЯм напИвэк." },
-      { "pl": "Napiwek już jest wliczony.", "ru": "Чаевые уже включены.", "ru_transcription": "напИвэк юж ест влИчоны." }
+      {
+        "pl": "Nowa wersja menu.",
+        "ru": "Новая версия меню.",
+        "ru_transcription": "нОва вЭрся мэню."
+      },
+      {
+        "pl": "W jakiej wersji?",
+        "ru": "В какой версии?",
+        "ru_transcription": "в якЕй вЭрси?"
+      }
     ],
-    "phrases_and_idioms": [
-      { "pl": "zostawiać napiwek", "ru": "оставлять чаевые" }
+    "inflection": {
+      "plural": {
+        "accusative": "wersje",
+        "dative": "wersjom",
+        "genitive": "wersji",
+        "instrumental": "wersjami",
+        "locative": "wersjach",
+        "nominative": "wersje",
+        "vocative": "wersje"
+      },
+      "singular": {
+        "accusative": "wersję",
+        "dative": "wersji",
+        "genitive": "wersji",
+        "instrumental": "wersją",
+        "locative": "wersji",
+        "nominative": "wersja",
+        "vocative": "wersjo"
+      }
+    },
+    "lemma": "wersja",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "вЭрся"
+    },
+    "translations": {
+      "ru": "версия"
+    }
+  },
+  "zamówienie": {
+    "applied_rules": [
+      "ó",
+      "ń"
     ],
-    "applied_rules": ["ó"]
+    "examples": [
+      {
+        "pl": "Przyjmuję zamówienie.",
+        "ru": "Принимаю заказ.",
+        "ru_transcription": "пшыймуЕм замувЕнЕ."
+      },
+      {
+        "pl": "Czy gotowe jest nasze zamówienie?",
+        "ru": "Готов ли наш заказ?",
+        "ru_transcription": "чы готОвэ ест нашэ замувЕнЕ?"
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "zamówienia",
+        "dative": "zamówieniom",
+        "genitive": "zamówień",
+        "instrumental": "zamówieniami",
+        "locative": "zamówieniach",
+        "nominative": "zamówienia",
+        "vocative": "zamówienia"
+      },
+      "singular": {
+        "accusative": "zamówienie",
+        "dative": "zamówieniu",
+        "genitive": "zamówienia",
+        "instrumental": "zamówieniem",
+        "locative": "zamówieniu",
+        "nominative": "zamówienie",
+        "vocative": "zamówienie"
+      }
+    },
+    "lemma": "zamówienie",
+    "morphology": {
+      "gender": "neuter"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "замувЕнЕ"
+    },
+    "translations": {
+      "ru": "заказ"
+    }
+  },
+  "zapłata": {
+    "applied_rules": [
+      "ł",
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Zapłata kartą.",
+        "ru": "Оплата картой.",
+        "ru_transcription": "запВАта картОм."
+      },
+      {
+        "pl": "Jaka forma zapłaty?",
+        "ru": "Какая форма оплаты?",
+        "ru_transcription": "яка фОрма запВАты?"
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "zapłaty",
+        "dative": "zapłatom",
+        "genitive": "zapłat",
+        "instrumental": "zapłatami",
+        "locative": "zapłatach",
+        "nominative": "zapłaty",
+        "vocative": "zapłaty"
+      },
+      "singular": {
+        "accusative": "zapłatę",
+        "dative": "zapłacie",
+        "genitive": "zapłaty",
+        "instrumental": "zapłatą",
+        "locative": "zapłacie",
+        "nominative": "zapłata",
+        "vocative": "zapłato"
+      }
+    },
+    "lemma": "zapłata",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "запВАта"
+    },
+    "translations": {
+      "ru": "оплата"
+    }
+  },
+  "zupa": {
+    "applied_rules": [
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Zamawiam zupę pomidorową.",
+        "ru": "Заказываю томатный суп.",
+        "ru_transcription": "замаВЯм зупЭм помидорОвОм."
+      },
+      {
+        "pl": "Ta zupa jest bardzo smaczna.",
+        "ru": "Этот суп очень вкусный.",
+        "ru_transcription": "та зупа ест бардзо смачна."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "zupy",
+        "dative": "zupom",
+        "genitive": "zup",
+        "instrumental": "zupami",
+        "locative": "zupach",
+        "nominative": "zupy",
+        "vocative": "zupy"
+      },
+      "singular": {
+        "accusative": "zupę",
+        "dative": "zupie",
+        "genitive": "zupy",
+        "instrumental": "zupą",
+        "locative": "zupie",
+        "nominative": "zupa",
+        "vocative": "zupo"
+      }
+    },
+    "lemma": "zupa",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "зупа"
+    },
+    "translations": {
+      "ru": "суп"
+    }
+  },
+  "śmietana": {
+    "applied_rules": [
+      "ś",
+      "ą",
+      "ę"
+    ],
+    "examples": [
+      {
+        "pl": "Zupa ze śmietaną.",
+        "ru": "Суп со сметаной.",
+        "ru_transcription": "зупа зэ шьмЕтаном."
+      },
+      {
+        "pl": "Świeża śmietana.",
+        "ru": "Свежая сметана.",
+        "ru_transcription": "шьвЕжа шьмЕтана."
+      }
+    ],
+    "inflection": {
+      "plural": {
+        "accusative": "śmietany",
+        "dative": "śmietanom",
+        "genitive": "śmietan",
+        "instrumental": "śmietanami",
+        "locative": "śmietanach",
+        "nominative": "śmietany",
+        "vocative": "śmietany"
+      },
+      "singular": {
+        "accusative": "śmietanę",
+        "dative": "śmietanie",
+        "genitive": "śmietany",
+        "instrumental": "śmietaną",
+        "locative": "śmietanie",
+        "nominative": "śmietana",
+        "vocative": "śmietano"
+      }
+    },
+    "lemma": "śmietana",
+    "morphology": {
+      "gender": "feminine"
+    },
+    "part_of_speech": "noun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "шьмЕтана"
+    },
+    "translations": {
+      "ru": "сметана"
+    }
   }
 }

--- a/data/dictionary/numbers/basic.json
+++ b/data/dictionary/numbers/basic.json
@@ -1,0 +1,156 @@
+{
+  "dwa": {
+    "applied_rules": [
+      "ó"
+    ],
+    "examples": [
+      {
+        "pl": "Dwa piwa, proszę.",
+        "ru": "Два пива, пожалуйста.",
+        "ru_transcription": "два пива прошэм."
+      },
+      {
+        "pl": "Dwie kawy.",
+        "ru": "Два кофе.",
+        "ru_transcription": "двЕ кавы."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "dwie",
+        "dative": "dwóm/dwom",
+        "genitive": "dwóch/dwu",
+        "instrumental": "dwoma",
+        "locative": "dwóch/dwu",
+        "nominative": "dwie",
+        "vocative": "dwie"
+      },
+      "masculine_neuter": {
+        "accusative": "dwa",
+        "dative": "dwóm/dwom",
+        "genitive": "dwóch/dwu",
+        "instrumental": "dwoma",
+        "locative": "dwóch/dwu",
+        "nominative": "dwa",
+        "vocative": "dwa"
+      }
+    },
+    "lemma": "dwa",
+    "morphology": {},
+    "part_of_speech": "numeral",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "dwie",
+          "ru": "двЕ"
+        }
+      ],
+      "ru_transcription": "два"
+    },
+    "translations": {
+      "ru": "два"
+    }
+  },
+  "jeden": {
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Jeden stolik dla dwóch osób.",
+        "ru": "Один столик на двоих.",
+        "ru_transcription": "Едэн столик для двух осуб."
+      },
+      {
+        "pl": "Jedna kawa, proszę.",
+        "ru": "Один кофе, пожалуйста.",
+        "ru_transcription": "Една кава прошэм."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "jedną",
+        "dative": "jednej",
+        "genitive": "jednej",
+        "instrumental": "jedną",
+        "locative": "jednej",
+        "nominative": "jedna",
+        "vocative": "jedna"
+      },
+      "masculine": {
+        "accusative": "jeden/jednego",
+        "dative": "jednemu",
+        "genitive": "jednego",
+        "instrumental": "jednym",
+        "locative": "jednym",
+        "nominative": "jeden",
+        "vocative": "jeden"
+      },
+      "neuter": {
+        "accusative": "jedno",
+        "dative": "jednemu",
+        "genitive": "jednego",
+        "instrumental": "jednym",
+        "locative": "jednym",
+        "nominative": "jedno",
+        "vocative": "jedno"
+      }
+    },
+    "lemma": "jeden",
+    "morphology": {},
+    "part_of_speech": "numeral",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "jedna",
+          "ru": "Една"
+        },
+        {
+          "pl": "jedno",
+          "ru": "Едно"
+        }
+      ],
+      "ru_transcription": "Едэн"
+    },
+    "translations": {
+      "ru": "один"
+    }
+  },
+  "kilka": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Kilka minut.",
+        "ru": "Несколько минут.",
+        "ru_transcription": "кИлька минут."
+      },
+      {
+        "pl": "Zamówiłem kilka dań.",
+        "ru": "Заказал несколько блюд.",
+        "ru_transcription": "замувИВэм кИлька дань."
+      }
+    ],
+    "inflection": {
+      "accusative": "kilka",
+      "dative": "kilku",
+      "genitive": "kilku",
+      "instrumental": "kilkoma",
+      "locative": "kilku",
+      "nominative": "kilka",
+      "vocative": "kilka"
+    },
+    "lemma": "kilka",
+    "morphology": {},
+    "part_of_speech": "numeral",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "кИлька"
+    },
+    "translations": {
+      "ru": "несколько"
+    }
+  }
+}

--- a/data/dictionary/particles/basic.json
+++ b/data/dictionary/particles/basic.json
@@ -1,0 +1,63 @@
+{
+  "nie": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Nie rozumiem.",
+        "ru": "Не понимаю.",
+        "ru_transcription": "нЭ розумЕм."
+      },
+      {
+        "pl": "To nie jest dobre.",
+        "ru": "Это нехорошо.",
+        "ru_transcription": "то нЭ ест добрэ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "nie",
+    "morphology": {},
+    "part_of_speech": "particle",
+    "phrases_and_idioms": [
+      {
+        "pl": "nie ma",
+        "ru": "нет"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "нЭ"
+    },
+    "translations": {
+      "ru": "не"
+    }
+  },
+  "też": {
+    "applied_rules": [
+      "ż"
+    ],
+    "examples": [
+      {
+        "pl": "Ja też chcę.",
+        "ru": "Я тоже хочу.",
+        "ru_transcription": "я тЭж хцэм."
+      },
+      {
+        "pl": "To też jest dobre.",
+        "ru": "Это тоже хорошо.",
+        "ru_transcription": "то тЭж ест добрэ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "też",
+    "morphology": {},
+    "part_of_speech": "particle",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "тЭж"
+    },
+    "translations": {
+      "ru": "тоже"
+    }
+  }
+}

--- a/data/dictionary/prepositions/basic.json
+++ b/data/dictionary/prepositions/basic.json
@@ -1,80 +1,248 @@
 {
-  "na": {
-    "lemma": "na",
-    "part_of_speech": "preposition",
-    "translations": { "ru": "на" },
-    "pronunciation": { 
-      "ru_transcription": "на",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
+  "dla": {
+    "applied_rules": [],
     "examples": [
-      { "pl": "Książka jest na stole.", "ru": "Книга на столе.", "ru_transcription": "кшёжка ест на столэ." },
-      { "pl": "Idę na pocztę.", "ru": "Иду на почту.", "ru_transcription": "идЭм на почтЭм." }
+      {
+        "pl": "Stolik dla dwóch osób.",
+        "ru": "Столик на двоих.",
+        "ru_transcription": "столик для двух осуб."
+      },
+      {
+        "pl": "Prezent dla ciebie.",
+        "ru": "Подарок для тебя.",
+        "ru_transcription": "прэзэнт для цЕбЕ."
+      }
     ],
-    "phrases_and_idioms": [
-      { "pl": "na pewno", "ru": "наверняка" },
-      { "pl": "na przykład", "ru": "например" }
-    ],
-    "applied_rules": []
-  },
-  "w": {
-    "lemma": "w",
-    "part_of_speech": "preposition",
-    "translations": { "ru": "в" },
-    "pronunciation": { 
-      "ru_transcription": "в",
-      "key_forms": []
-    },
-    "morphology": {},
     "inflection": {},
-    "examples": [
-      { "pl": "Jestem w domu.", "ru": "Я дома.", "ru_transcription": "естэм в дому." },
-      { "pl": "W poniedziałek mam lekcje.", "ru": "В понедельник у меня уроки.", "ru_transcription": "в понЭдзяВЭк мам лЭкцЕ." }
-    ],
-    "phrases_and_idioms": [
-      { "pl": "w końcu", "ru": "наконец" },
-      { "pl": "w ogóle", "ru": "вообще" }
-    ],
-    "applied_rules": []
+    "lemma": "dla",
+    "morphology": {},
+    "part_of_speech": "preposition",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "для"
+    },
+    "translations": {
+      "ru": "для"
+    }
   },
   "do": {
-    "lemma": "do",
-    "part_of_speech": "preposition",
-    "translations": { "ru": "к, до, в" },
-    "pronunciation": { 
-      "ru_transcription": "до",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
+    "applied_rules": [],
     "examples": [
-      { "pl": "Idę do sklepu.", "ru": "Иду в магазин.", "ru_transcription": "идЭм до склЭпу." },
-      { "pl": "Od rana do wieczora.", "ru": "С утра до вечера.", "ru_transcription": "од рана до вЭчора." }
+      {
+        "pl": "Idę do sklepu.",
+        "ru": "Иду в магазин.",
+        "ru_transcription": "идЭм до склЭпу."
+      },
+      {
+        "pl": "Od rana do wieczora.",
+        "ru": "С утра до вечера.",
+        "ru_transcription": "од рана до вЭчора."
+      }
     ],
+    "inflection": {},
+    "lemma": "do",
+    "morphology": {},
+    "part_of_speech": "preposition",
     "phrases_and_idioms": [
-      { "pl": "do widzenia", "ru": "до свидания" }
+      {
+        "pl": "do widzenia",
+        "ru": "до свидания"
+      }
     ],
-    "applied_rules": []
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "до"
+    },
+    "translations": {
+      "ru": "к, до, в"
+    }
+  },
+  "na": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Książka jest na stole.",
+        "ru": "Книга на столе.",
+        "ru_transcription": "кшёжка ест на столэ."
+      },
+      {
+        "pl": "Idę na pocztę.",
+        "ru": "Иду на почту.",
+        "ru_transcription": "идЭм на почтЭм."
+      }
+    ],
+    "inflection": {},
+    "lemma": "na",
+    "morphology": {},
+    "part_of_speech": "preposition",
+    "phrases_and_idioms": [
+      {
+        "pl": "na pewno",
+        "ru": "наверняка"
+      },
+      {
+        "pl": "na przykład",
+        "ru": "например"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "на"
+    },
+    "translations": {
+      "ru": "на"
+    }
+  },
+  "o": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Myślę o tobie.",
+        "ru": "Думаю о тебе.",
+        "ru_transcription": "мышлЭм о тобЕ."
+      },
+      {
+        "pl": "Opowiadaj o sobie.",
+        "ru": "Рассказывай о себе.",
+        "ru_transcription": "опоВЯдай о собЕ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "o",
+    "morphology": {},
+    "part_of_speech": "preposition",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "о"
+    },
+    "translations": {
+      "ru": "о, об"
+    }
+  },
+  "przy": {
+    "applied_rules": [
+      "rz"
+    ],
+    "examples": [
+      {
+        "pl": "Stolik przy oknie.",
+        "ru": "Столик у окна.",
+        "ru_transcription": "столик пшы окьнЭ."
+      },
+      {
+        "pl": "Siedzę przy stole.",
+        "ru": "Сижу за столом.",
+        "ru_transcription": "шЁдзэм пшы столэ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "przy",
+    "morphology": {},
+    "part_of_speech": "preposition",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "пшы"
+    },
+    "translations": {
+      "ru": "при, у"
+    }
+  },
+  "w": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Jestem w domu.",
+        "ru": "Я дома.",
+        "ru_transcription": "естэм в дому."
+      },
+      {
+        "pl": "W poniedziałek mam lekcje.",
+        "ru": "В понедельник у меня уроки.",
+        "ru_transcription": "в понЭдзяВЭк мам лЭкцЕ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "w",
+    "morphology": {},
+    "part_of_speech": "preposition",
+    "phrases_and_idioms": [
+      {
+        "pl": "w końcu",
+        "ru": "наконец"
+      },
+      {
+        "pl": "w ogóle",
+        "ru": "вообще"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "в"
+    },
+    "translations": {
+      "ru": "в"
+    }
   },
   "z": {
-    "lemma": "z",
-    "part_of_speech": "preposition",
-    "translations": { "ru": "с, из" },
-    "pronunciation": { 
-      "ru_transcription": "з",
-      "key_forms": []
-    },
-    "morphology": {},
-    "inflection": {},
+    "applied_rules": [],
     "examples": [
-      { "pl": "Idę z przyjacielem.", "ru": "Иду с другом.", "ru_transcription": "идЭм з пшыяцЕлем." },
-      { "pl": "Wracam z pracy.", "ru": "Возвращаюсь с работы.", "ru_transcription": "врацам з працы." }
+      {
+        "pl": "Idę z przyjacielem.",
+        "ru": "Иду с другом.",
+        "ru_transcription": "идЭм з пшыяцЕлем."
+      },
+      {
+        "pl": "Wracam z pracy.",
+        "ru": "Возвращаюсь с работы.",
+        "ru_transcription": "врацам з працы."
+      }
     ],
+    "inflection": {},
+    "lemma": "z",
+    "morphology": {},
+    "part_of_speech": "preposition",
     "phrases_and_idioms": [
-      { "pl": "z przyjemnością", "ru": "с удовольствием" }
+      {
+        "pl": "z przyjemnością",
+        "ru": "с удовольствием"
+      }
     ],
-    "applied_rules": []
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "з"
+    },
+    "translations": {
+      "ru": "с, из"
+    }
+  },
+  "za": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Dziękuję za pomoc.",
+        "ru": "Спасибо за помощь.",
+        "ru_transcription": "дзЁнкуЕм за помоц."
+      },
+      {
+        "pl": "Zapłaciłem za obiad.",
+        "ru": "Заплатил за обед.",
+        "ru_transcription": "запВАциВэм за обЯд."
+      }
+    ],
+    "inflection": {},
+    "lemma": "za",
+    "morphology": {},
+    "part_of_speech": "preposition",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "за"
+    },
+    "translations": {
+      "ru": "за"
+    }
   }
 }

--- a/data/dictionary/pronouns/demonstrative.json
+++ b/data/dictionary/pronouns/demonstrative.json
@@ -1,0 +1,253 @@
+{
+  "coś": {
+    "applied_rules": [
+      "ś",
+      "cz"
+    ],
+    "examples": [
+      {
+        "pl": "Chcę coś zjeść.",
+        "ru": "Хочу что-то съесть.",
+        "ru_transcription": "хцэм цошь зьЕшч."
+      },
+      {
+        "pl": "Czy coś jeszcze?",
+        "ru": "Что-нибудь ещё?",
+        "ru_transcription": "чы цошь ЕшчЭ?"
+      }
+    ],
+    "inflection": {
+      "accusative": "coś",
+      "dative": "czemuś",
+      "genitive": "czegoś",
+      "instrumental": "czymś",
+      "locative": "czymś",
+      "nominative": "coś"
+    },
+    "lemma": "coś",
+    "morphology": {},
+    "part_of_speech": "pronoun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "цошь"
+    },
+    "translations": {
+      "ru": "что-то"
+    }
+  },
+  "nasz": {
+    "applied_rules": [
+      "sz",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "To nasz stolik.",
+        "ru": "Это наш столик.",
+        "ru_transcription": "то наш столик."
+      },
+      {
+        "pl": "Nasza rezerwacja.",
+        "ru": "Наша бронь.",
+        "ru_transcription": "наша рэзэрваця."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "naszą",
+        "dative": "naszej",
+        "genitive": "naszej",
+        "instrumental": "naszą",
+        "locative": "naszej",
+        "nominative": "nasza",
+        "vocative": "nasza"
+      },
+      "masculine": {
+        "accusative": "nasz/naszego",
+        "dative": "naszemu",
+        "genitive": "naszego",
+        "instrumental": "naszym",
+        "locative": "naszym",
+        "nominative": "nasz",
+        "vocative": "nasz"
+      },
+      "neuter": {
+        "accusative": "nasze",
+        "dative": "naszemu",
+        "genitive": "naszego",
+        "instrumental": "naszym",
+        "locative": "naszym",
+        "nominative": "nasze",
+        "vocative": "nasze"
+      }
+    },
+    "lemma": "nasz",
+    "morphology": {},
+    "part_of_speech": "pronoun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "nasza",
+          "ru": "наша"
+        },
+        {
+          "pl": "nasze",
+          "ru": "нашЭ"
+        }
+      ],
+      "ru_transcription": "наш"
+    },
+    "translations": {
+      "ru": "наш"
+    }
+  },
+  "ten": {
+    "applied_rules": [
+      "ę",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Ten stolik jest wolny.",
+        "ru": "Этот столик свободен.",
+        "ru_transcription": "тэн столик ест вольны."
+      },
+      {
+        "pl": "Ta restauracja jest dobra.",
+        "ru": "Этот ресторан хороший.",
+        "ru_transcription": "та рэстауРАця ест добра."
+      }
+    ],
+    "inflection": {
+      "feminine": {
+        "accusative": "tę",
+        "dative": "tej",
+        "genitive": "tej",
+        "instrumental": "tą",
+        "locative": "tej",
+        "nominative": "ta",
+        "vocative": "ta"
+      },
+      "masculine": {
+        "accusative": "ten/tego",
+        "dative": "temu",
+        "genitive": "tego",
+        "instrumental": "tym",
+        "locative": "tym",
+        "nominative": "ten",
+        "vocative": "ten"
+      },
+      "neuter": {
+        "accusative": "to",
+        "dative": "temu",
+        "genitive": "tego",
+        "instrumental": "tym",
+        "locative": "tym",
+        "nominative": "to",
+        "vocative": "to"
+      }
+    },
+    "lemma": "ten",
+    "morphology": {},
+    "part_of_speech": "pronoun",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "ta",
+          "ru": "та"
+        },
+        {
+          "pl": "to",
+          "ru": "то"
+        }
+      ],
+      "ru_transcription": "тэн"
+    },
+    "translations": {
+      "ru": "этот"
+    }
+  },
+  "to": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "To jest dobre.",
+        "ru": "Это хорошо.",
+        "ru_transcription": "то ест добрэ."
+      },
+      {
+        "pl": "Co to jest?",
+        "ru": "Что это такое?",
+        "ru_transcription": "цо то ест?"
+      }
+    ],
+    "inflection": {
+      "accusative": "to",
+      "dative": "temu",
+      "genitive": "tego",
+      "instrumental": "tym",
+      "locative": "tym",
+      "nominative": "to"
+    },
+    "lemma": "to",
+    "morphology": {},
+    "part_of_speech": "pronoun",
+    "phrases_and_idioms": [
+      {
+        "pl": "to znaczy",
+        "ru": "то есть"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "то"
+    },
+    "translations": {
+      "ru": "это"
+    }
+  },
+  "wszystko": {
+    "applied_rules": [
+      "sz"
+    ],
+    "examples": [
+      {
+        "pl": "Wszystko w porządku.",
+        "ru": "Всё в порядке.",
+        "ru_transcription": "вшыстко в поРОндку."
+      },
+      {
+        "pl": "To wszystko.",
+        "ru": "Это всё.",
+        "ru_transcription": "то вшыстко."
+      }
+    ],
+    "inflection": {
+      "accusative": "wszystko",
+      "dative": "wszystkiemu",
+      "genitive": "wszystkiego",
+      "instrumental": "wszystkim",
+      "locative": "wszystkim",
+      "nominative": "wszystko"
+    },
+    "lemma": "wszystko",
+    "morphology": {},
+    "part_of_speech": "pronoun",
+    "phrases_and_idioms": [
+      {
+        "pl": "wszystko jedno",
+        "ru": "всё равно"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "вшыстко"
+    },
+    "translations": {
+      "ru": "всё"
+    }
+  }
+}

--- a/data/dictionary/punctuation/basic.json
+++ b/data/dictionary/punctuation/basic.json
@@ -1,0 +1,29 @@
+{
+  "–": {
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "Dzień – noc.",
+        "ru": "День — ночь.",
+        "ru_transcription": "джэнь — ноц."
+      },
+      {
+        "pl": "To jest – oczywiście – niemożliwe.",
+        "ru": "Это — конечно — невозможно.",
+        "ru_transcription": "то ест — очывИшчЕ — нЭможлИвэ."
+      }
+    ],
+    "inflection": {},
+    "lemma": "–",
+    "morphology": {},
+    "part_of_speech": "punctuation",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [],
+      "ru_transcription": "тирЭ"
+    },
+    "translations": {
+      "ru": "тире"
+    }
+  }
+}

--- a/data/dictionary/verbs/basic.json
+++ b/data/dictionary/verbs/basic.json
@@ -1,207 +1,1519 @@
 {
-  "być": {
-    "lemma": "być",
-    "part_of_speech": "verb",
-    "translations": { "ru": "быть" },
-    "pronunciation": { 
-      "ru_transcription": "быч",
-      "key_forms": [
-        { "pl": "jestem", "ru": "ЕСТЭМ" },
-        { "pl": "jesteś", "ru": "ЕС-ТЕШЬ" },
-        { "pl": "jest", "ru": "ЕСТ" },
-        { "pl": "są", "ru": "С(оу̃)" }
-      ]
+  "brzmieć": {
+    "applied_rules": [
+      "rz",
+      "ć",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "To brzmi dobrze.",
+        "ru": "Это звучит хорошо.",
+        "ru_transcription": "То бжми добжэ."
+      },
+      {
+        "pl": "Jak to brzmi po polsku?",
+        "ru": "Как это звучит по-польски?",
+        "ru_transcription": "як то бжми по польску?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy brzmieli",
+        "pl2": "będziecie brzmieli",
+        "pl3": "będą brzmieli",
+        "sg1": "będę brzmiał/brzmiała",
+        "sg2": "będziesz brzmiał/brzmiała",
+        "sg3": "będzie brzmiał/brzmiała"
+      },
+      "imperative": {},
+      "past_fem": {
+        "pl1": "brzmiałyśmy",
+        "pl2": "brzmiałyście",
+        "pl3": "brzmiały",
+        "sg1": "brzmiałam",
+        "sg2": "brzmiałaś",
+        "sg3": "brzmiała"
+      },
+      "past_masc": {
+        "pl1": "brzmielihmy",
+        "pl2": "brzmielihcie",
+        "pl3": "brzmieli",
+        "sg1": "brzmiałem",
+        "sg2": "brzmiałeś",
+        "sg3": "brzmiał"
+      },
+      "past_neut": {
+        "sg3": "brzmiało"
+      },
+      "present": {
+        "pl1": "brzmimy",
+        "pl2": "brzmicie",
+        "pl3": "brzmią",
+        "sg1": "brzmię",
+        "sg2": "brzmisz",
+        "sg3": "brzmi"
+      }
     },
+    "lemma": "brzmieć",
     "morphology": {
       "aspect": "imperfective",
-      "transitivity": "intransitive",
-      "reflexive": false
+      "reflexive": false,
+      "transitivity": "intransitive"
     },
-    "inflection": {
-      "present": { "sg1": "jestem", "sg2": "jesteś", "sg3": "jest", "pl1": "jesteśmy", "pl2": "jesteście", "pl3": "są" },
-      "past_masc": { "sg1": "byłem", "sg2": "byłeś", "sg3": "był", "pl1": "byliśmy", "pl2": "byliście", "pl3": "byli" },
-      "past_fem": { "sg1": "byłam", "sg2": "byłaś", "sg3": "była", "pl1": "byłyśmy", "pl2": "byłyście", "pl3": "były" },
-      "past_neut": { "sg3": "było" },
-      "future": { "sg1": "będę", "sg2": "będziesz", "sg3": "będzie", "pl1": "będziemy", "pl2": "będziecie", "pl3": "będą" },
-      "imperative": { "sg2": "bądź", "pl1": "bądźmy", "pl2": "bądźcie" }
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "brzmi",
+          "ru": "БЖМИ"
+        },
+        {
+          "pl": "brzmią",
+          "ru": "БЖМЁ(oн̃)"
+        }
+      ],
+      "ru_transcription": "бжмэч"
     },
+    "translations": {
+      "ru": "звучать"
+    }
+  },
+  "być": {
+    "applied_rules": [
+      "ć",
+      "ł",
+      "ą",
+      "ę"
+    ],
     "examples": [
-      { "pl": "Jestem zmęczony.", "ru": "Я устал.", "ru_transcription": "Естэм змэнчоный." },
-      { "pl": "Czy jesteście gotowi?", "ru": "Вы готовы?", "ru_transcription": "чы ес-ТЭШЬ-че готови?" },
-      { "pl": "Wczoraj byłam w kinie.", "ru": "Вчера я была в кино.", "ru_transcription": "вчорай быуам в кинэ." }
+      {
+        "pl": "Jestem zmęczony.",
+        "ru": "Я устал.",
+        "ru_transcription": "Естэм змэнчоный."
+      },
+      {
+        "pl": "Czy jesteście gotowi?",
+        "ru": "Вы готовы?",
+        "ru_transcription": "чы ес-ТЭШЬ-че готови?"
+      },
+      {
+        "pl": "Wczoraj byłam w kinie.",
+        "ru": "Вчера я была в кино.",
+        "ru_transcription": "вчорай быуам в кинэ."
+      }
     ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy",
+        "pl2": "będziecie",
+        "pl3": "będą",
+        "sg1": "będę",
+        "sg2": "będziesz",
+        "sg3": "będzie"
+      },
+      "imperative": {
+        "pl1": "bądźmy",
+        "pl2": "bądźcie",
+        "sg2": "bądź"
+      },
+      "past_fem": {
+        "pl1": "byłyśmy",
+        "pl2": "byłyście",
+        "pl3": "były",
+        "sg1": "byłam",
+        "sg2": "byłaś",
+        "sg3": "była"
+      },
+      "past_masc": {
+        "pl1": "byliśmy",
+        "pl2": "byliście",
+        "pl3": "byli",
+        "sg1": "byłem",
+        "sg2": "byłeś",
+        "sg3": "był"
+      },
+      "past_neut": {
+        "sg3": "było"
+      },
+      "present": {
+        "pl1": "jesteśmy",
+        "pl2": "jesteście",
+        "pl3": "są",
+        "sg1": "jestem",
+        "sg2": "jesteś",
+        "sg3": "jest"
+      }
+    },
+    "lemma": "być",
+    "morphology": {
+      "aspect": "imperfective",
+      "reflexive": false,
+      "transitivity": "intransitive"
+    },
+    "part_of_speech": "verb",
     "phrases_and_idioms": [
-      { "pl": "być może", "ru": "возможно" },
-      { "pl": "być w stanie", "ru": "быть в состоянии" }
+      {
+        "pl": "być może",
+        "ru": "возможно"
+      },
+      {
+        "pl": "być w stanie",
+        "ru": "быть в состоянии"
+      }
     ],
-    "applied_rules": ["ć", "ł", "ą", "ę"]
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "jestem",
+          "ru": "ЕСТЭМ"
+        },
+        {
+          "pl": "jesteś",
+          "ru": "ЕС-ТЕШЬ"
+        },
+        {
+          "pl": "jest",
+          "ru": "ЕСТ"
+        },
+        {
+          "pl": "są",
+          "ru": "С(оу̃)"
+        }
+      ],
+      "ru_transcription": "быч"
+    },
+    "translations": {
+      "ru": "быть"
+    }
   },
   "chcieć": {
+    "applied_rules": [
+      "ć",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Chcę kawę.",
+        "ru": "Я хочу кофе.",
+        "ru_transcription": "Хцэм кавэ."
+      },
+      {
+        "pl": "Co chcesz zamówić?",
+        "ru": "Что ты хочешь заказать?",
+        "ru_transcription": "цо хцешь замувич?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy chcieli",
+        "pl2": "będziecie chcieli",
+        "pl3": "będą chcieli",
+        "sg1": "będę chciał/chciała",
+        "sg2": "będziesz chciał/chciała",
+        "sg3": "będzie chciał/chciała"
+      },
+      "imperative": {},
+      "past_fem": {
+        "pl1": "chciałyśmy",
+        "pl2": "chciałyście",
+        "pl3": "chciały",
+        "sg1": "chciałam",
+        "sg2": "chciałaś",
+        "sg3": "chciała"
+      },
+      "past_masc": {
+        "pl1": "chcieliśmy",
+        "pl2": "chcieliście",
+        "pl3": "chcieli",
+        "sg1": "chciałem",
+        "sg2": "chciałeś",
+        "sg3": "chciał"
+      },
+      "past_neut": {
+        "sg3": "chciało"
+      },
+      "present": {
+        "pl1": "chcemy",
+        "pl2": "chcecie",
+        "pl3": "chcą",
+        "sg1": "chcę",
+        "sg2": "chcesz",
+        "sg3": "chce"
+      }
+    },
     "lemma": "chcieć",
-    "part_of_speech": "verb",
-    "translations": { "ru": "хотеть" },
-    "pronunciation": { 
-      "ru_transcription": "хцэч",
-      "key_forms": [
-        { "pl": "chcę", "ru": "ХЦЭМ" },
-        { "pl": "chcesz", "ru": "ХЦЕШЬ" },
-        { "pl": "chce", "ru": "ХЦЭ" }
-      ]
-    },
     "morphology": {
       "aspect": "imperfective",
-      "transitivity": "transitive",
-      "reflexive": false
+      "reflexive": false,
+      "transitivity": "transitive"
     },
-    "inflection": {
-      "present": { "sg1": "chcę", "sg2": "chcesz", "sg3": "chce", "pl1": "chcemy", "pl2": "chcecie", "pl3": "chcą" },
-      "past_masc": { "sg1": "chciałem", "sg2": "chciałeś", "sg3": "chciał", "pl1": "chcieliśmy", "pl2": "chcieliście", "pl3": "chcieli" },
-      "past_fem": { "sg1": "chciałam", "sg2": "chciałaś", "sg3": "chciała", "pl1": "chciałyśmy", "pl2": "chciałyście", "pl3": "chciały" },
-      "past_neut": { "sg3": "chciało" },
-      "future": { "sg1": "będę chciał/chciała", "sg2": "będziesz chciał/chciała", "sg3": "będzie chciał/chciała", "pl1": "będziemy chcieli", "pl2": "będziecie chcieli", "pl3": "będą chcieli" },
-      "imperative": {}
-    },
-    "examples": [
-      { "pl": "Chcę kawę.", "ru": "Я хочу кофе.", "ru_transcription": "Хцэм кавэ." },
-      { "pl": "Co chcesz zamówić?", "ru": "Что ты хочешь заказать?", "ru_transcription": "цо хцешь замувич?" }
-    ],
+    "part_of_speech": "verb",
     "phrases_and_idioms": [
-      { "pl": "chcieć czy nie chcieć", "ru": "хочешь не хочешь" }
+      {
+        "pl": "chcieć czy nie chcieć",
+        "ru": "хочешь не хочешь"
+      }
     ],
-    "applied_rules": ["ć", "ą"]
-  },
-  "brzmieć": {
-    "lemma": "brzmieć",
-    "part_of_speech": "verb",
-    "translations": { "ru": "звучать" },
-    "pronunciation": { 
-      "ru_transcription": "бжмэч",
+    "pronunciation": {
       "key_forms": [
-        { "pl": "brzmi", "ru": "БЖМИ" },
-        { "pl": "brzmią", "ru": "БЖМЁ(oн̃)" }
-      ]
+        {
+          "pl": "chcę",
+          "ru": "ХЦЭМ"
+        },
+        {
+          "pl": "chcesz",
+          "ru": "ХЦЕШЬ"
+        },
+        {
+          "pl": "chce",
+          "ru": "ХЦЭ"
+        }
+      ],
+      "ru_transcription": "хцэч"
     },
+    "translations": {
+      "ru": "хотеть"
+    }
+  },
+  "cieszyć": {
+    "applied_rules": [
+      "ć",
+      "ą",
+      "ę",
+      "ł"
+    ],
+    "examples": [
+      {
+        "pl": "Cieszę się z twojego sukcesu.",
+        "ru": "Радуюсь твоему успеху.",
+        "ru_transcription": "цЕшэм сЯ з твоЕго сукцЭсу."
+      },
+      {
+        "pl": "Bardzo się cieszę!",
+        "ru": "Очень радуюсь!",
+        "ru_transcription": "бардзо сЯ цЕшэм!"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy cieszyli",
+        "pl2": "będziecie cieszyli",
+        "pl3": "będą cieszyli",
+        "sg1": "będę cieszył/cieszyła",
+        "sg2": "będziesz cieszył/cieszyła",
+        "sg3": "będzie cieszył/cieszyła"
+      },
+      "imperative": {
+        "pl1": "cieszmy",
+        "pl2": "cieszcie",
+        "sg2": "ciesz"
+      },
+      "past_fem": {
+        "pl1": "cieszyłyśmy",
+        "pl2": "cieszyłyście",
+        "pl3": "cieszyły",
+        "sg1": "cieszyłam",
+        "sg2": "cieszyłaś",
+        "sg3": "cieszyła"
+      },
+      "past_masc": {
+        "pl1": "cieszyliśmy",
+        "pl2": "cieszyliście",
+        "pl3": "cieszyli",
+        "sg1": "cieszyłem",
+        "sg2": "cieszyłeś",
+        "sg3": "cieszył"
+      },
+      "past_neut": {
+        "sg3": "cieszyło"
+      },
+      "present": {
+        "pl1": "cieszymy",
+        "pl2": "cieszycie",
+        "pl3": "cieszą",
+        "sg1": "cieszę",
+        "sg2": "cieszysz",
+        "sg3": "cieszy"
+      }
+    },
+    "lemma": "cieszyć",
     "morphology": {
       "aspect": "imperfective",
-      "transitivity": "intransitive",
-      "reflexive": false
+      "reflexive": true,
+      "transitivity": "intransitive"
     },
-    "inflection": {
-      "present": { "sg1": "brzmię", "sg2": "brzmisz", "sg3": "brzmi", "pl1": "brzmimy", "pl2": "brzmicie", "pl3": "brzmią" },
-      "past_masc": { "sg1": "brzmiałem", "sg2": "brzmiałeś", "sg3": "brzmiał", "pl1": "brzmielihmy", "pl2": "brzmielihcie", "pl3": "brzmieli" },
-      "past_fem": { "sg1": "brzmiałam", "sg2": "brzmiałaś", "sg3": "brzmiała", "pl1": "brzmiałyśmy", "pl2": "brzmiałyście", "pl3": "brzmiały" },
-      "past_neut": { "sg3": "brzmiało" },
-      "future": { "sg1": "będę brzmiał/brzmiała", "sg2": "będziesz brzmiał/brzmiała", "sg3": "będzie brzmiał/brzmiała", "pl1": "będziemy brzmieli", "pl2": "będziecie brzmieli", "pl3": "będą brzmieli" },
-      "imperative": {}
-    },
-    "examples": [
-      { "pl": "To brzmi dobrze.", "ru": "Это звучит хорошо.", "ru_transcription": "То бжми добжэ." },
-      { "pl": "Jak to brzmi po polsku?", "ru": "Как это звучит по-польски?", "ru_transcription": "як то бжми по польску?" }
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [
+      {
+        "pl": "cieszyć się",
+        "ru": "радоваться"
+      }
     ],
-    "phrases_and_idioms": [],
-    "applied_rules": ["rz", "ć", "ą"]
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "cieszę",
+          "ru": "цЕшэм"
+        },
+        {
+          "pl": "cieszysz",
+          "ru": "цЕшышь"
+        },
+        {
+          "pl": "cieszy",
+          "ru": "цЕшы"
+        }
+      ],
+      "ru_transcription": "цЕшыч"
+    },
+    "translations": {
+      "ru": "радоваться"
+    }
   },
   "dać": {
-    "lemma": "dać",
-    "part_of_speech": "verb",
-    "translations": { "ru": "дать" },
-    "pronunciation": { 
-      "ru_transcription": "дач",
-      "key_forms": [
-        { "pl": "dam", "ru": "ДАМ" },
-        { "pl": "dasz", "ru": "ДАШЬ" },
-        { "pl": "da", "ru": "ДА" }
-      ]
+    "applied_rules": [
+      "ć",
+      "ł",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Dam ci pieniądze.",
+        "ru": "Дам тебе деньги.",
+        "ru_transcription": "Дам ци пэнёндзэ."
+      },
+      {
+        "pl": "Daj mi, proszę, sól.",
+        "ru": "Дай мне, пожалуйста, соль.",
+        "ru_transcription": "дай ми прошэ сул."
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "damy",
+        "pl2": "dacie",
+        "pl3": "dadzą",
+        "sg1": "dam",
+        "sg2": "dasz",
+        "sg3": "da"
+      },
+      "imperative": {
+        "pl1": "dajmy",
+        "pl2": "dajcie",
+        "sg2": "daj"
+      },
+      "past_fem": {
+        "pl1": "dałyśmy",
+        "pl2": "dałyście",
+        "pl3": "dały",
+        "sg1": "dałam",
+        "sg2": "dałaś",
+        "sg3": "dała"
+      },
+      "past_masc": {
+        "pl1": "daliśmy",
+        "pl2": "daliście",
+        "pl3": "dali",
+        "sg1": "dałem",
+        "sg2": "dałeś",
+        "sg3": "dał"
+      },
+      "past_neut": {
+        "sg3": "dało"
+      },
+      "present": {}
     },
+    "lemma": "dać",
     "morphology": {
       "aspect": "perfective",
-      "transitivity": "transitive",
-      "reflexive": false
+      "reflexive": false,
+      "transitivity": "transitive"
     },
-    "inflection": {
-      "present": {},
-      "past_masc": { "sg1": "dałem", "sg2": "dałeś", "sg3": "dał", "pl1": "daliśmy", "pl2": "daliście", "pl3": "dali" },
-      "past_fem": { "sg1": "dałam", "sg2": "dałaś", "sg3": "dała", "pl1": "dałyśmy", "pl2": "dałyście", "pl3": "dały" },
-      "past_neut": { "sg3": "dało" },
-      "future": { "sg1": "dam", "sg2": "dasz", "sg3": "da", "pl1": "damy", "pl2": "dacie", "pl3": "dadzą" },
-      "imperative": { "sg2": "daj", "pl1": "dajmy", "pl2": "dajcie" }
-    },
-    "examples": [
-      { "pl": "Dam ci pieniądze.", "ru": "Дам тебе деньги.", "ru_transcription": "Дам ци пэнёндзэ." },
-      { "pl": "Daj mi, proszę, sól.", "ru": "Дай мне, пожалуйста, соль.", "ru_transcription": "дай ми прошэ сул." }
-    ],
+    "part_of_speech": "verb",
     "phrases_and_idioms": [
-      { "pl": "dać sobie radę", "ru": "справиться" }
+      {
+        "pl": "dać sobie radę",
+        "ru": "справиться"
+      }
     ],
-    "applied_rules": ["ć", "ł", "ą"]
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "dam",
+          "ru": "ДАМ"
+        },
+        {
+          "pl": "dasz",
+          "ru": "ДАШЬ"
+        },
+        {
+          "pl": "da",
+          "ru": "ДА"
+        }
+      ],
+      "ru_transcription": "дач"
+    },
+    "translations": {
+      "ru": "дать"
+    }
+  },
+  "dodać": {
+    "applied_rules": [
+      "ć",
+      "ł",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Dodam trochę soli.",
+        "ru": "Добавлю немного соли.",
+        "ru_transcription": "додАМ трохэм соли."
+      },
+      {
+        "pl": "Czy mogę dodać cukru?",
+        "ru": "Могу добавить сахару?",
+        "ru_transcription": "чы могЭм додач цукру?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "dodamy",
+        "pl2": "dodacie",
+        "pl3": "dodadzą",
+        "sg1": "dodam",
+        "sg2": "dodasz",
+        "sg3": "doda"
+      },
+      "imperative": {
+        "pl1": "dodajmy",
+        "pl2": "dodajcie",
+        "sg2": "dodaj"
+      },
+      "past_fem": {
+        "pl1": "dodałyśmy",
+        "pl2": "dodałyście",
+        "pl3": "dodały",
+        "sg1": "dodałam",
+        "sg2": "dodałaś",
+        "sg3": "dodała"
+      },
+      "past_masc": {
+        "pl1": "dodaliśmy",
+        "pl2": "dodaliście",
+        "pl3": "dodali",
+        "sg1": "dodałem",
+        "sg2": "dodałeś",
+        "sg3": "dodał"
+      },
+      "past_neut": {
+        "sg3": "dodało"
+      },
+      "present": {}
+    },
+    "lemma": "dodać",
+    "morphology": {
+      "aspect": "perfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "dodam",
+          "ru": "додАМ"
+        },
+        {
+          "pl": "dodasz",
+          "ru": "додАШЬ"
+        },
+        {
+          "pl": "doda",
+          "ru": "додА"
+        }
+      ],
+      "ru_transcription": "додач"
+    },
+    "translations": {
+      "ru": "добавить"
+    }
+  },
+  "dopisywać": {
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Dopisuję nowe słowa do słownika.",
+        "ru": "Дописываю новые слова в словарь.",
+        "ru_transcription": "допИсуЕм новэ слова до словника."
+      },
+      {
+        "pl": "Czy możesz dopisać adres?",
+        "ru": "Можешь дописать адрес?",
+        "ru_transcription": "чы можешь допИсач адрэс?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy dopisywali",
+        "pl2": "będziecie dopisywali",
+        "pl3": "będą dopisywali",
+        "sg1": "będę dopisywał/dopisywała",
+        "sg2": "będziesz dopisywał/dopisywała",
+        "sg3": "będzie dopisywał/dopisywała"
+      },
+      "imperative": {
+        "pl1": "dopisujmy",
+        "pl2": "dopisujcie",
+        "sg2": "dopisuj"
+      },
+      "past_fem": {
+        "pl1": "dopisywałyśmy",
+        "pl2": "dopisywałyście",
+        "pl3": "dopisywały",
+        "sg1": "dopisywałam",
+        "sg2": "dopisywałaś",
+        "sg3": "dopisywała"
+      },
+      "past_masc": {
+        "pl1": "dopisywaliśmy",
+        "pl2": "dopisywaliście",
+        "pl3": "dopisywali",
+        "sg1": "dopisywałem",
+        "sg2": "dopisywałeś",
+        "sg3": "dopisywał"
+      },
+      "past_neut": {
+        "sg3": "dopisywało"
+      },
+      "present": {
+        "pl1": "dopisujemy",
+        "pl2": "dopisujecie",
+        "pl3": "dopisują",
+        "sg1": "dopisuję",
+        "sg2": "dopisujesz",
+        "sg3": "dopisuje"
+      }
+    },
+    "lemma": "dopisywać",
+    "morphology": {
+      "aspect": "imperfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "dopisuję",
+          "ru": "допИсуЕм"
+        },
+        {
+          "pl": "dopisujesz",
+          "ru": "допИсуЕшь"
+        },
+        {
+          "pl": "dopisuje",
+          "ru": "допИсуЕ"
+        }
+      ],
+      "ru_transcription": "допИсывач"
+    },
+    "translations": {
+      "ru": "дописывать"
+    }
+  },
+  "dziękować": {
+    "applied_rules": [
+      "ę",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Dziękuję za pomoc.",
+        "ru": "Спасибо за помощь.",
+        "ru_transcription": "дзЁнкуЕм за помоц."
+      },
+      {
+        "pl": "Bardzo dziękuję!",
+        "ru": "Большое спасибо!",
+        "ru_transcription": "бардзо дзЁнкуЕм!"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy dziękowali",
+        "pl2": "będziecie dziękowali",
+        "pl3": "będą dziękowali",
+        "sg1": "będę dziękował/dziękowała",
+        "sg2": "będziesz dziękował/dziękowała",
+        "sg3": "będzie dziękował/dziękowała"
+      },
+      "imperative": {
+        "pl1": "dziękujmy",
+        "pl2": "dziękujcie",
+        "sg2": "dziękuj"
+      },
+      "past_fem": {
+        "pl1": "dziękowałyśmy",
+        "pl2": "dziękowałyście",
+        "pl3": "dziękowały",
+        "sg1": "dziękowałam",
+        "sg2": "dziękowałaś",
+        "sg3": "dziękowała"
+      },
+      "past_masc": {
+        "pl1": "dziękowaliśmy",
+        "pl2": "dziękowaliście",
+        "pl3": "dziękowali",
+        "sg1": "dziękowałem",
+        "sg2": "dziękowałeś",
+        "sg3": "dziękował"
+      },
+      "past_neut": {
+        "sg3": "dziękowało"
+      },
+      "present": {
+        "pl1": "dziękujemy",
+        "pl2": "dziękujecie",
+        "pl3": "dziękują",
+        "sg1": "dziękuję",
+        "sg2": "dziękujesz",
+        "sg3": "dziękuje"
+      }
+    },
+    "lemma": "dziękować",
+    "morphology": {
+      "aspect": "imperfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [
+      {
+        "pl": "dziękuję bardzo",
+        "ru": "большое спасибо"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "dziękuję",
+          "ru": "дзЁнкуЕм"
+        },
+        {
+          "pl": "dziękujesz",
+          "ru": "дзЁнкуЕшь"
+        },
+        {
+          "pl": "dziękuje",
+          "ru": "дзЁнкуЕ"
+        }
+      ],
+      "ru_transcription": "дзЁнкОвач"
+    },
+    "translations": {
+      "ru": "благодарить"
+    }
   },
   "mieć": {
-    "lemma": "mieć",
-    "part_of_speech": "verb",
-    "translations": { "ru": "иметь" },
-    "pronunciation": { 
-      "ru_transcription": "мэч",
-      "key_forms": [
-        { "pl": "mam", "ru": "МАМ" },
-        { "pl": "masz", "ru": "МАШЬ" },
-        { "pl": "ma", "ru": "МА" }
-      ]
+    "applied_rules": [
+      "ć",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Mam psa.",
+        "ru": "У меня есть собака.",
+        "ru_transcription": "Мам пса."
+      },
+      {
+        "pl": "Czy masz czas?",
+        "ru": "У тебя есть время?",
+        "ru_transcription": "чы машь час?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy mieli",
+        "pl2": "będziecie mieli",
+        "pl3": "będą mieli",
+        "sg1": "będę miał/miała",
+        "sg2": "będziesz miał/miała",
+        "sg3": "będzie miał/miała"
+      },
+      "imperative": {
+        "pl1": "miejmy",
+        "pl2": "miejcie",
+        "sg2": "miej"
+      },
+      "past_fem": {
+        "pl1": "miałyśmy",
+        "pl2": "miałyście",
+        "pl3": "miały",
+        "sg1": "miałam",
+        "sg2": "miałaś",
+        "sg3": "miała"
+      },
+      "past_masc": {
+        "pl1": "mieliśmy",
+        "pl2": "mieliście",
+        "pl3": "mieli",
+        "sg1": "miałem",
+        "sg2": "miałeś",
+        "sg3": "miał"
+      },
+      "past_neut": {
+        "sg3": "miało"
+      },
+      "present": {
+        "pl1": "mamy",
+        "pl2": "macie",
+        "pl3": "mają",
+        "sg1": "mam",
+        "sg2": "masz",
+        "sg3": "ma"
+      }
     },
+    "lemma": "mieć",
     "morphology": {
       "aspect": "imperfective",
-      "transitivity": "transitive",
-      "reflexive": false
+      "reflexive": false,
+      "transitivity": "transitive"
     },
-    "inflection": {
-      "present": { "sg1": "mam", "sg2": "masz", "sg3": "ma", "pl1": "mamy", "pl2": "macie", "pl3": "mają" },
-      "past_masc": { "sg1": "miałem", "sg2": "miałeś", "sg3": "miał", "pl1": "mieliśmy", "pl2": "mieliście", "pl3": "mieli" },
-      "past_fem": { "sg1": "miałam", "sg2": "miałaś", "sg3": "miała", "pl1": "miałyśmy", "pl2": "miałyście", "pl3": "miały" },
-      "past_neut": { "sg3": "miało" },
-      "future": { "sg1": "będę miał/miała", "sg2": "będziesz miał/miała", "sg3": "będzie miał/miała", "pl1": "będziemy mieli", "pl2": "będziecie mieli", "pl3": "będą mieli" },
-      "imperative": { "sg2": "miej", "pl1": "miejmy", "pl2": "miejcie" }
-    },
-    "examples": [
-      { "pl": "Mam psa.", "ru": "У меня есть собака.", "ru_transcription": "Мам пса." },
-      { "pl": "Czy masz czas?", "ru": "У тебя есть время?", "ru_transcription": "чы машь час?" }
-    ],
+    "part_of_speech": "verb",
     "phrases_and_idioms": [
-      { "pl": "mieć rację", "ru": "быть правым" },
-      { "pl": "mieć ochotę", "ru": "хотеть" }
+      {
+        "pl": "mieć rację",
+        "ru": "быть правым"
+      },
+      {
+        "pl": "mieć ochotę",
+        "ru": "хотеть"
+      }
     ],
-    "applied_rules": ["ć", "ą"]
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "mam",
+          "ru": "МАМ"
+        },
+        {
+          "pl": "masz",
+          "ru": "МАШЬ"
+        },
+        {
+          "pl": "ma",
+          "ru": "МА"
+        }
+      ],
+      "ru_transcription": "мэч"
+    },
+    "translations": {
+      "ru": "иметь"
+    }
   },
   "móc": {
-    "lemma": "móc",
-    "part_of_speech": "verb",
-    "translations": { "ru": "мочь" },
-    "pronunciation": { 
-      "ru_transcription": "муц",
-      "key_forms": [
-        { "pl": "mogę", "ru": "МОГЭМ" },
-        { "pl": "możesz", "ru": "МОЖЕШЬ" },
-        { "pl": "może", "ru": "МОЖЭ" }
-      ]
+    "applied_rules": [
+      "ó",
+      "ć",
+      "ą",
+      "ę",
+      "ż"
+    ],
+    "examples": [
+      {
+        "pl": "Mogę ci pomóc.",
+        "ru": "Я могу тебе помочь.",
+        "ru_transcription": "могэм ци помуц."
+      },
+      {
+        "pl": "Czy możesz przyjść?",
+        "ru": "Можешь прийти?",
+        "ru_transcription": "чы можешь пшийшьч?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy mogli",
+        "pl2": "będziecie mogli",
+        "pl3": "będą mogli",
+        "sg1": "będę mógł/mogła",
+        "sg2": "będziesz mógł/mogła",
+        "sg3": "będzie mógł/mogła"
+      },
+      "imperative": {},
+      "past_fem": {
+        "pl1": "mogłyśmy",
+        "pl2": "mogłyście",
+        "pl3": "mogły",
+        "sg1": "mogłam",
+        "sg2": "mogłaś",
+        "sg3": "mogła"
+      },
+      "past_masc": {
+        "pl1": "mogliśmy",
+        "pl2": "mogliście",
+        "pl3": "mogli",
+        "sg1": "mogłem",
+        "sg2": "mogłeś",
+        "sg3": "mógł"
+      },
+      "past_neut": {
+        "sg3": "mogło"
+      },
+      "present": {
+        "pl1": "możemy",
+        "pl2": "możecie",
+        "pl3": "mogą",
+        "sg1": "mogę",
+        "sg2": "możesz",
+        "sg3": "może"
+      }
     },
+    "lemma": "móc",
     "morphology": {
       "aspect": "imperfective",
-      "transitivity": "transitive",
-      "reflexive": false
+      "reflexive": false,
+      "transitivity": "transitive"
     },
-    "inflection": {
-      "present": { "sg1": "mogę", "sg2": "możesz", "sg3": "może", "pl1": "możemy", "pl2": "możecie", "pl3": "mogą" },
-      "past_masc": { "sg1": "mogłem", "sg2": "mogłeś", "sg3": "mógł", "pl1": "mogliśmy", "pl2": "mogliście", "pl3": "mogli" },
-      "past_fem": { "sg1": "mogłam", "sg2": "mogłaś", "sg3": "mogła", "pl1": "mogłyśmy", "pl2": "mogłyście", "pl3": "mogły" },
-      "past_neut": { "sg3": "mogło" },
-      "future": { "sg1": "będę mógł/mogła", "sg2": "będziesz mógł/mogła", "sg3": "będzie mógł/mogła", "pl1": "będziemy mogli", "pl2": "będziecie mogli", "pl3": "będą mogli" },
-      "imperative": {}
-    },
-    "examples": [
-      { "pl": "Mogę ci pomóc.", "ru": "Я могу тебе помочь.", "ru_transcription": "могэм ци помуц." },
-      { "pl": "Czy możesz przyjść?", "ru": "Можешь прийти?", "ru_transcription": "чы можешь пшийшьч?" }
-    ],
+    "part_of_speech": "verb",
     "phrases_and_idioms": [
-      { "pl": "może być", "ru": "может быть" }
+      {
+        "pl": "może być",
+        "ru": "может быть"
+      }
     ],
-    "applied_rules": ["ó", "ć", "ą", "ę", "ż"]
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "mogę",
+          "ru": "МОГЭМ"
+        },
+        {
+          "pl": "możesz",
+          "ru": "МОЖЕШЬ"
+        },
+        {
+          "pl": "może",
+          "ru": "МОЖЭ"
+        }
+      ],
+      "ru_transcription": "муц"
+    },
+    "translations": {
+      "ru": "мочь"
+    }
+  },
+  "potrzebować": {
+    "applied_rules": [
+      "rz",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Potrzebuję pomocy.",
+        "ru": "Мне нужна помощь.",
+        "ru_transcription": "потшЭбуЕм помоцы."
+      },
+      {
+        "pl": "Czego potrzebujesz?",
+        "ru": "Что тебе нужно?",
+        "ru_transcription": "чЭго потшЭбуЕшь?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy potrzebowali",
+        "pl2": "będziecie potrzebowali",
+        "pl3": "będą potrzebowali",
+        "sg1": "będę potrzebował/potrzebowała",
+        "sg2": "będziesz potrzebował/potrzebowała",
+        "sg3": "będzie potrzebował/potrzebowała"
+      },
+      "imperative": {
+        "pl1": "potrzebujmy",
+        "pl2": "potrzebujcie",
+        "sg2": "potrzebuj"
+      },
+      "past_fem": {
+        "pl1": "potrzebowałyśmy",
+        "pl2": "potrzebowałyście",
+        "pl3": "potrzebowały",
+        "sg1": "potrzebowałam",
+        "sg2": "potrzebowałaś",
+        "sg3": "potrzebowała"
+      },
+      "past_masc": {
+        "pl1": "potrzebowaliśmy",
+        "pl2": "potrzebowaliście",
+        "pl3": "potrzebowali",
+        "sg1": "potrzebowałem",
+        "sg2": "potrzebowałeś",
+        "sg3": "potrzebował"
+      },
+      "past_neut": {
+        "sg3": "potrzebowało"
+      },
+      "present": {
+        "pl1": "potrzebujemy",
+        "pl2": "potrzebujecie",
+        "pl3": "potrzebują",
+        "sg1": "potrzebuję",
+        "sg2": "potrzebujesz",
+        "sg3": "potrzebuje"
+      }
+    },
+    "lemma": "potrzebować",
+    "morphology": {
+      "aspect": "imperfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "potrzebuję",
+          "ru": "потшЭбуЕм"
+        },
+        {
+          "pl": "potrzebujesz",
+          "ru": "потшЭбуЕшь"
+        },
+        {
+          "pl": "potrzebuje",
+          "ru": "потшЭбуЕ"
+        }
+      ],
+      "ru_transcription": "потшЭбОвач"
+    },
+    "translations": {
+      "ru": "нуждаться"
+    }
+  },
+  "prosić": {
+    "applied_rules": [
+      "ć",
+      "ś",
+      "ą",
+      "ę",
+      "ł"
+    ],
+    "examples": [
+      {
+        "pl": "Proszę o rachunek.",
+        "ru": "Прошу счёт.",
+        "ru_transcription": "прошЭм о рахунэк."
+      },
+      {
+        "pl": "Czy mogę prosić?",
+        "ru": "Можно попросить?",
+        "ru_transcription": "чы могЭм прошИч?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy prosili",
+        "pl2": "będziecie prosili",
+        "pl3": "będą prosili",
+        "sg1": "będę prosił/prosiła",
+        "sg2": "będziesz prosił/prosiła",
+        "sg3": "będzie prosił/prosiła"
+      },
+      "imperative": {
+        "pl1": "prośmy",
+        "pl2": "proście",
+        "sg2": "proś"
+      },
+      "past_fem": {
+        "pl1": "prosiłyśmy",
+        "pl2": "prosiłyście",
+        "pl3": "prosiły",
+        "sg1": "prosiłam",
+        "sg2": "prosiłaś",
+        "sg3": "prosiła"
+      },
+      "past_masc": {
+        "pl1": "prosiliśmy",
+        "pl2": "prosiliście",
+        "pl3": "prosili",
+        "sg1": "prosiłem",
+        "sg2": "prosiłeś",
+        "sg3": "prosił"
+      },
+      "past_neut": {
+        "sg3": "prosiło"
+      },
+      "present": {
+        "pl1": "prosimy",
+        "pl2": "prosicie",
+        "pl3": "proszą",
+        "sg1": "proszę",
+        "sg2": "prosisz",
+        "sg3": "prosi"
+      }
+    },
+    "lemma": "prosić",
+    "morphology": {
+      "aspect": "imperfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [
+      {
+        "pl": "proszę bardzo",
+        "ru": "пожалуйста"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "proszę",
+          "ru": "прошЭм"
+        },
+        {
+          "pl": "prosisz",
+          "ru": "прошИшь"
+        },
+        {
+          "pl": "prosi",
+          "ru": "прошИ"
+        }
+      ],
+      "ru_transcription": "прошИч"
+    },
+    "translations": {
+      "ru": "просить"
+    }
+  },
+  "przygotować": {
+    "applied_rules": [
+      "rz",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Przygotujemy kolację.",
+        "ru": "Приготовим ужин.",
+        "ru_transcription": "пшыготУЕмы колацьем."
+      },
+      {
+        "pl": "Czy możesz przygotować kawę?",
+        "ru": "Можешь приготовить кофе?",
+        "ru_transcription": "чы можешь пшыготОвач кавэм?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "przygotujemy",
+        "pl2": "przygotujecie",
+        "pl3": "przygotują",
+        "sg1": "przygotuję",
+        "sg2": "przygotujesz",
+        "sg3": "przygotuje"
+      },
+      "imperative": {
+        "pl1": "przygotujmy",
+        "pl2": "przygotujcie",
+        "sg2": "przygotuj"
+      },
+      "past_fem": {
+        "pl1": "przygotowałyśmy",
+        "pl2": "przygotowałyście",
+        "pl3": "przygotowały",
+        "sg1": "przygotowałam",
+        "sg2": "przygotowałaś",
+        "sg3": "przygotowała"
+      },
+      "past_masc": {
+        "pl1": "przygotowaliśmy",
+        "pl2": "przygotowaliście",
+        "pl3": "przygotowali",
+        "sg1": "przygotowałem",
+        "sg2": "przygotowałeś",
+        "sg3": "przygotował"
+      },
+      "past_neut": {
+        "sg3": "przygotowało"
+      },
+      "present": {}
+    },
+    "lemma": "przygotować",
+    "morphology": {
+      "aspect": "perfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "przygotuję",
+          "ru": "пшыготУЕм"
+        },
+        {
+          "pl": "przygotujesz",
+          "ru": "пшыготУЕшь"
+        },
+        {
+          "pl": "przygotuje",
+          "ru": "пшыготУЕ"
+        }
+      ],
+      "ru_transcription": "пшыготОвач"
+    },
+    "translations": {
+      "ru": "приготовить"
+    }
+  },
+  "przyjąć": {
+    "applied_rules": [
+      "rz",
+      "ą",
+      "ę",
+      "ł"
+    ],
+    "examples": [
+      {
+        "pl": "Przyjmę zamówienie.",
+        "ru": "Приму заказ.",
+        "ru_transcription": "пшыймЭм замувЕнЕ."
+      },
+      {
+        "pl": "Czy Pan przyjmie zaproszenie?",
+        "ru": "Примете приглашение?",
+        "ru_transcription": "чы пан пшыймЕ запрошЕнЕ?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "przyjmiemy",
+        "pl2": "przyjmiecie",
+        "pl3": "przyjmą",
+        "sg1": "przyjmę",
+        "sg2": "przyjmiesz",
+        "sg3": "przyjmie"
+      },
+      "imperative": {
+        "pl1": "przyjmijmy",
+        "pl2": "przyjmijcie",
+        "sg2": "przyjmij"
+      },
+      "past_fem": {
+        "pl1": "przyjęłyśmy",
+        "pl2": "przyjęłyście",
+        "pl3": "przyjęły",
+        "sg1": "przyjęłam",
+        "sg2": "przyjęłaś",
+        "sg3": "przyjęła"
+      },
+      "past_masc": {
+        "pl1": "przyjęliśmy",
+        "pl2": "przyjęliście",
+        "pl3": "przyjęli",
+        "sg1": "przyjąłem",
+        "sg2": "przyjąłeś",
+        "sg3": "przyjął"
+      },
+      "past_neut": {
+        "sg3": "przyjęło"
+      },
+      "present": {}
+    },
+    "lemma": "przyjąć",
+    "morphology": {
+      "aspect": "perfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "przyjmę",
+          "ru": "пшыймЭм"
+        },
+        {
+          "pl": "przyjmiesz",
+          "ru": "пшыймЕшь"
+        },
+        {
+          "pl": "przyjmie",
+          "ru": "пшыймЕ"
+        }
+      ],
+      "ru_transcription": "пшыёнч"
+    },
+    "translations": {
+      "ru": "принять"
+    }
+  },
+  "usiąść": {
+    "applied_rules": [
+      "ś",
+      "ą",
+      "ł"
+    ],
+    "examples": [
+      {
+        "pl": "Proszę usiąść.",
+        "ru": "Садитесь, пожалуйста.",
+        "ru_transcription": "прошэм ушёншч."
+      },
+      {
+        "pl": "Gdzie mam usiąść?",
+        "ru": "Где мне сесть?",
+        "ru_transcription": "гдзЕ мам ушёншч?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "usiądziemy",
+        "pl2": "usiądziecie",
+        "pl3": "usiądą",
+        "sg1": "usiądę",
+        "sg2": "usiądziesz",
+        "sg3": "usiądzie"
+      },
+      "imperative": {
+        "pl1": "usiądźmy",
+        "pl2": "usiądźcie",
+        "sg2": "usiądź"
+      },
+      "past_fem": {
+        "pl1": "usiadłyśmy",
+        "pl2": "usiadłyście",
+        "pl3": "usiadły",
+        "sg1": "usiadłam",
+        "sg2": "usiadłaś",
+        "sg3": "usiadła"
+      },
+      "past_masc": {
+        "pl1": "usiedliśmy",
+        "pl2": "usiedliście",
+        "pl3": "usiedli",
+        "sg1": "usiadłem",
+        "sg2": "usiadłeś",
+        "sg3": "usiadł"
+      },
+      "past_neut": {
+        "sg3": "usiadło"
+      },
+      "present": {}
+    },
+    "lemma": "usiąść",
+    "morphology": {
+      "aspect": "perfective",
+      "reflexive": false,
+      "transitivity": "intransitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "usiądę",
+          "ru": "ушёндЭм"
+        },
+        {
+          "pl": "usiądziesz",
+          "ru": "ушёндзЕшь"
+        },
+        {
+          "pl": "usiądzie",
+          "ru": "ушёндзЕ"
+        }
+      ],
+      "ru_transcription": "ушёншч"
+    },
+    "translations": {
+      "ru": "сесть"
+    }
+  },
+  "witać": {
+    "applied_rules": [
+      "ć",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Witam Państwa!",
+        "ru": "Приветствую Вас!",
+        "ru_transcription": "вИтам пАньства!"
+      },
+      {
+        "pl": "Witamy w naszej restauracji.",
+        "ru": "Добро пожаловать в наш ресторан.",
+        "ru_transcription": "вИтамы в нашэй рэстаурацьи."
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy witali",
+        "pl2": "będziecie witali",
+        "pl3": "będą witali",
+        "sg1": "będę witał/witała",
+        "sg2": "będziesz witał/witała",
+        "sg3": "będzie witał/witała"
+      },
+      "imperative": {
+        "pl1": "witajmy",
+        "pl2": "witajcie",
+        "sg2": "witaj"
+      },
+      "past_fem": {
+        "pl1": "witałyśmy",
+        "pl2": "witałyście",
+        "pl3": "witały",
+        "sg1": "witałam",
+        "sg2": "witałaś",
+        "sg3": "witała"
+      },
+      "past_masc": {
+        "pl1": "witaliśmy",
+        "pl2": "witaliście",
+        "pl3": "witali",
+        "sg1": "witałem",
+        "sg2": "witałeś",
+        "sg3": "witał"
+      },
+      "past_neut": {
+        "sg3": "witało"
+      },
+      "present": {
+        "pl1": "witamy",
+        "pl2": "witacie",
+        "pl3": "witają",
+        "sg1": "witam",
+        "sg2": "witasz",
+        "sg3": "wita"
+      }
+    },
+    "lemma": "witać",
+    "morphology": {
+      "aspect": "imperfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [
+      {
+        "pl": "witaj",
+        "ru": "привет"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "witam",
+          "ru": "вИтам"
+        },
+        {
+          "pl": "witasz",
+          "ru": "вИташь"
+        },
+        {
+          "pl": "wita",
+          "ru": "вИта"
+        }
+      ],
+      "ru_transcription": "вИтач"
+    },
+    "translations": {
+      "ru": "приветствовать"
+    }
+  },
+  "wrócić": {
+    "applied_rules": [
+      "ó",
+      "ć",
+      "ł",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Wrócę za godzinę.",
+        "ru": "Вернусь через час.",
+        "ru_transcription": "вруцЭм за годзИнэм."
+      },
+      {
+        "pl": "Kiedy wrócisz?",
+        "ru": "Когда вернёшься?",
+        "ru_transcription": "кеды вруцИшь?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "wrócimy",
+        "pl2": "wrócicie",
+        "pl3": "wrócą",
+        "sg1": "wrócę",
+        "sg2": "wrócisz",
+        "sg3": "wróci"
+      },
+      "imperative": {
+        "pl1": "wróćmy",
+        "pl2": "wróćcie",
+        "sg2": "wróć"
+      },
+      "past_fem": {
+        "pl1": "wróciłyśmy",
+        "pl2": "wróciłyście",
+        "pl3": "wróciły",
+        "sg1": "wróciłam",
+        "sg2": "wróciłaś",
+        "sg3": "wróciła"
+      },
+      "past_masc": {
+        "pl1": "wróciliśmy",
+        "pl2": "wróciliście",
+        "pl3": "wrócili",
+        "sg1": "wróciłem",
+        "sg2": "wróciłeś",
+        "sg3": "wrócił"
+      },
+      "past_neut": {
+        "sg3": "wróciło"
+      },
+      "present": {}
+    },
+    "lemma": "wrócić",
+    "morphology": {
+      "aspect": "perfective",
+      "reflexive": false,
+      "transitivity": "intransitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "wrócę",
+          "ru": "вруцЭм"
+        },
+        {
+          "pl": "wrócisz",
+          "ru": "вруцИшь"
+        },
+        {
+          "pl": "wróci",
+          "ru": "вруцИ"
+        }
+      ],
+      "ru_transcription": "вруцИч"
+    },
+    "translations": {
+      "ru": "вернуться"
+    }
   }
 }

--- a/data/dictionary/verbs/restaurant.json
+++ b/data/dictionary/verbs/restaurant.json
@@ -1,197 +1,699 @@
 {
-  "zamawiać": {
-    "lemma": "zamawiać",
-    "part_of_speech": "verb",
-    "translations": { "ru": "заказывать" },
-    "pronunciation": { 
-      "ru_transcription": "замавЯч",
-      "key_forms": [
-        { "pl": "zamawiam", "ru": "замаВЯМ" },
-        { "pl": "zamawiasz", "ru": "замаВЯШЬ" },
-        { "pl": "zamawia", "ru": "замаВЯ" }
-      ]
-    },
-    "morphology": {
-      "aspect": "imperfective",
-      "transitivity": "transitive",
-      "reflexive": false
-    },
-    "inflection": {
-      "present": { "sg1": "zamawiam", "sg2": "zamawiasz", "sg3": "zamawia", "pl1": "zamawiamy", "pl2": "zamawiacie", "pl3": "zamawiają" },
-      "past_masc": { "sg1": "zamawiałem", "sg2": "zamawiałeś", "sg3": "zamawiał", "pl1": "zamawialiśmy", "pl2": "zamawialiście", "pl3": "zamawiali" },
-      "past_fem": { "sg1": "zamawiałam", "sg2": "zamawiałaś", "sg3": "zamawiała", "pl1": "zamawiałyśmy", "pl2": "zamawiałyście", "pl3": "zamawiały" },
-      "past_neut": { "sg3": "zamawiało" },
-      "future": { "sg1": "będę zamawiał/zamawiała", "sg2": "będziesz zamawiał/zamawiała", "sg3": "będzie zamawiał/zamawiała", "pl1": "będziemy zamawiali", "pl2": "będziecie zamawiali", "pl3": "będą zamawiali" },
-      "imperative": { "sg2": "zamawiaj", "pl1": "zamawiajmy", "pl2": "zamawiajcie" }
-    },
-    "examples": [
-      { "pl": "Zamawiam zupę.", "ru": "Заказываю суп.", "ru_transcription": "замаВЯМ зупэм." },
-      { "pl": "Co Pan zamawia?", "ru": "Что Вы заказываете?", "ru_transcription": "цо пан замаВЯ?" }
-    ],
-    "phrases_and_idioms": [],
-    "applied_rules": ["ą"]
-  },
   "podawać": {
-    "lemma": "podawać",
-    "part_of_speech": "verb",
-    "translations": { "ru": "подавать" },
-    "pronunciation": { 
-      "ru_transcription": "подаВАч",
-      "key_forms": [
-        { "pl": "podaję", "ru": "подаЁм" },
-        { "pl": "podajesz", "ru": "подаЕШЬ" },
-        { "pl": "podaje", "ru": "подаЕ" }
-      ]
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Kelner podaje kawę.",
+        "ru": "Официант подаёт кофе.",
+        "ru_transcription": "кэльнэр подаЕ кавэм."
+      },
+      {
+        "pl": "Podaję na stół.",
+        "ru": "Подаю на стол.",
+        "ru_transcription": "подаЁм на стул."
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy podawali",
+        "pl2": "będziecie podawali",
+        "pl3": "będą podawali",
+        "sg1": "będę podawał/podawała",
+        "sg2": "będziesz podawał/podawała",
+        "sg3": "będzie podawał/podawała"
+      },
+      "imperative": {
+        "pl1": "podawajmy",
+        "pl2": "podawajcie",
+        "sg2": "podawaj"
+      },
+      "past_fem": {
+        "pl1": "podawałyśmy",
+        "pl2": "podawałyście",
+        "pl3": "podawały",
+        "sg1": "podawałam",
+        "sg2": "podawałaś",
+        "sg3": "podawała"
+      },
+      "past_masc": {
+        "pl1": "podawaliśmy",
+        "pl2": "podawaliście",
+        "pl3": "podawali",
+        "sg1": "podawałem",
+        "sg2": "podawałeś",
+        "sg3": "podawał"
+      },
+      "past_neut": {
+        "sg3": "podawało"
+      },
+      "present": {
+        "pl1": "podajemy",
+        "pl2": "podajecie",
+        "pl3": "podają",
+        "sg1": "podaję",
+        "sg2": "podajesz",
+        "sg3": "podaje"
+      }
     },
+    "lemma": "podawać",
     "morphology": {
       "aspect": "imperfective",
-      "transitivity": "transitive",
-      "reflexive": false
+      "reflexive": false,
+      "transitivity": "transitive"
     },
-    "inflection": {
-      "present": { "sg1": "podaję", "sg2": "podajesz", "sg3": "podaje", "pl1": "podajemy", "pl2": "podajecie", "pl3": "podają" },
-      "past_masc": { "sg1": "podawałem", "sg2": "podawałeś", "sg3": "podawał", "pl1": "podawaliśmy", "pl2": "podawaliście", "pl3": "podawali" },
-      "past_fem": { "sg1": "podawałam", "sg2": "podawałaś", "sg3": "podawała", "pl1": "podawałyśmy", "pl2": "podawałyście", "pl3": "podawały" },
-      "past_neut": { "sg3": "podawało" },
-      "future": { "sg1": "będę podawał/podawała", "sg2": "będziesz podawał/podawała", "sg3": "będzie podawał/podawała", "pl1": "będziemy podawali", "pl2": "będziecie podawali", "pl3": "będą podawali" },
-      "imperative": { "sg2": "podawaj", "pl1": "podawajmy", "pl2": "podawajcie" }
-    },
-    "examples": [
-      { "pl": "Kelner podaje kawę.", "ru": "Официант подаёт кофе.", "ru_transcription": "кэльнэр подаЕ кавэм." },
-      { "pl": "Podaję na stół.", "ru": "Подаю на стол.", "ru_transcription": "подаЁм на стул." }
-    ],
+    "part_of_speech": "verb",
     "phrases_and_idioms": [
-      { "pl": "podawać do stołu", "ru": "подавать к столу" }
+      {
+        "pl": "podawać do stołu",
+        "ru": "подавать к столу"
+      }
     ],
-    "applied_rules": ["ą"]
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "podaję",
+          "ru": "подаЁм"
+        },
+        {
+          "pl": "podajesz",
+          "ru": "подаЕШЬ"
+        },
+        {
+          "pl": "podaje",
+          "ru": "подаЕ"
+        }
+      ],
+      "ru_transcription": "подаВАч"
+    },
+    "translations": {
+      "ru": "подавать"
+    }
   },
   "podać": {
-    "lemma": "podać",
-    "part_of_speech": "verb",
-    "translations": { "ru": "подать" },
-    "pronunciation": { 
-      "ru_transcription": "подач",
-      "key_forms": [
-        { "pl": "podam", "ru": "подАМ" },
-        { "pl": "podasz", "ru": "подАШЬ" },
-        { "pl": "poda", "ru": "подА" }
-      ]
+    "applied_rules": [
+      "ć",
+      "ł",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Podam ci menu.",
+        "ru": "Подам тебе меню.",
+        "ru_transcription": "подАМ ци мэню."
+      },
+      {
+        "pl": "Proszę podać rachunek.",
+        "ru": "Подайте, пожалуйста, счёт.",
+        "ru_transcription": "прошэм подач рахунэк."
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "podamy",
+        "pl2": "podacie",
+        "pl3": "podadzą",
+        "sg1": "podam",
+        "sg2": "podasz",
+        "sg3": "poda"
+      },
+      "imperative": {
+        "pl1": "podajmy",
+        "pl2": "podajcie",
+        "sg2": "podaj"
+      },
+      "past_fem": {
+        "pl1": "podałyśmy",
+        "pl2": "podałyście",
+        "pl3": "podały",
+        "sg1": "podałam",
+        "sg2": "podałaś",
+        "sg3": "podała"
+      },
+      "past_masc": {
+        "pl1": "podaliśmy",
+        "pl2": "podaliście",
+        "pl3": "podali",
+        "sg1": "podałem",
+        "sg2": "podałeś",
+        "sg3": "podał"
+      },
+      "past_neut": {
+        "sg3": "podało"
+      },
+      "present": {}
     },
+    "lemma": "podać",
     "morphology": {
       "aspect": "perfective",
-      "transitivity": "transitive",
-      "reflexive": false
+      "reflexive": false,
+      "transitivity": "transitive"
     },
-    "inflection": {
-      "present": {},
-      "past_masc": { "sg1": "podałem", "sg2": "podałeś", "sg3": "podał", "pl1": "podaliśmy", "pl2": "podaliście", "pl3": "podali" },
-      "past_fem": { "sg1": "podałam", "sg2": "podałaś", "sg3": "podała", "pl1": "podałyśmy", "pl2": "podałyście", "pl3": "podały" },
-      "past_neut": { "sg3": "podało" },
-      "future": { "sg1": "podam", "sg2": "podasz", "sg3": "poda", "pl1": "podamy", "pl2": "podacie", "pl3": "podadzą" },
-      "imperative": { "sg2": "podaj", "pl1": "podajmy", "pl2": "podajcie" }
-    },
-    "examples": [
-      { "pl": "Podam ci menu.", "ru": "Подам тебе меню.", "ru_transcription": "подАМ ци мэню." },
-      { "pl": "Proszę podać rachunek.", "ru": "Подайте, пожалуйста, счёт.", "ru_transcription": "прошэм подач рахунэк." }
-    ],
+    "part_of_speech": "verb",
     "phrases_and_idioms": [
-      { "pl": "podać rękę", "ru": "подать руку" }
+      {
+        "pl": "podać rękę",
+        "ru": "подать руку"
+      }
     ],
-    "applied_rules": ["ć", "ł", "ą"]
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "podam",
+          "ru": "подАМ"
+        },
+        {
+          "pl": "podasz",
+          "ru": "подАШЬ"
+        },
+        {
+          "pl": "poda",
+          "ru": "подА"
+        }
+      ],
+      "ru_transcription": "подач"
+    },
+    "translations": {
+      "ru": "подать"
+    }
   },
   "polecać": {
-    "lemma": "polecać",
-    "part_of_speech": "verb",
-    "translations": { "ru": "рекомендовать" },
-    "pronunciation": { 
-      "ru_transcription": "полЭцач",
-      "key_forms": [
-        { "pl": "polecam", "ru": "полЭцам" },
-        { "pl": "polecasz", "ru": "полЭцашь" },
-        { "pl": "poleca", "ru": "полЭца" }
-      ]
+    "applied_rules": [
+      "ć",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Polecam tę restaurację.",
+        "ru": "Рекомендую этот ресторан.",
+        "ru_transcription": "полЭцам тэм рэстауРАцьем."
+      },
+      {
+        "pl": "Co Pan poleca?",
+        "ru": "Что Вы рекомендуете?",
+        "ru_transcription": "цо пан полЭца?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy polecali",
+        "pl2": "będziecie polecali",
+        "pl3": "będą polecali",
+        "sg1": "będę polecał/polecała",
+        "sg2": "będziesz polecał/polecała",
+        "sg3": "będzie polecał/polecała"
+      },
+      "imperative": {
+        "pl1": "polecajmy",
+        "pl2": "polecajcie",
+        "sg2": "polecaj"
+      },
+      "past_fem": {
+        "pl1": "polecałyśmy",
+        "pl2": "polecałyście",
+        "pl3": "polecały",
+        "sg1": "polecałam",
+        "sg2": "polecałaś",
+        "sg3": "polecała"
+      },
+      "past_masc": {
+        "pl1": "polecaliśmy",
+        "pl2": "polecaliście",
+        "pl3": "polecali",
+        "sg1": "polecałem",
+        "sg2": "polecałeś",
+        "sg3": "polecał"
+      },
+      "past_neut": {
+        "sg3": "polecało"
+      },
+      "present": {
+        "pl1": "polecamy",
+        "pl2": "polecacie",
+        "pl3": "polecają",
+        "sg1": "polecam",
+        "sg2": "polecasz",
+        "sg3": "poleca"
+      }
     },
+    "lemma": "polecać",
     "morphology": {
       "aspect": "imperfective",
-      "transitivity": "transitive",
-      "reflexive": false
+      "reflexive": false,
+      "transitivity": "transitive"
     },
-    "inflection": {
-      "present": { "sg1": "polecam", "sg2": "polecasz", "sg3": "poleca", "pl1": "polecamy", "pl2": "polecacie", "pl3": "polecają" },
-      "past_masc": { "sg1": "polecałem", "sg2": "polecałeś", "sg3": "polecał", "pl1": "polecaliśmy", "pl2": "polecaliście", "pl3": "polecali" },
-      "past_fem": { "sg1": "polecałam", "sg2": "polecałaś", "sg3": "polecała", "pl1": "polecałyśmy", "pl2": "polecałyście", "pl3": "polecały" },
-      "past_neut": { "sg3": "polecało" },
-      "future": { "sg1": "będę polecał/polecała", "sg2": "będziesz polecał/polecała", "sg3": "będzie polecał/polecała", "pl1": "będziemy polecali", "pl2": "będziecie polecali", "pl3": "będą polecali" },
-      "imperative": { "sg2": "polecaj", "pl1": "polecajmy", "pl2": "polecajcie" }
-    },
-    "examples": [
-      { "pl": "Polecam tę restaurację.", "ru": "Рекомендую этот ресторан.", "ru_transcription": "полЭцам тэм рэстауРАцьем." },
-      { "pl": "Co Pan poleca?", "ru": "Что Вы рекомендуете?", "ru_transcription": "цо пан полЭца?" }
-    ],
+    "part_of_speech": "verb",
     "phrases_and_idioms": [],
-    "applied_rules": ["ć", "ą"]
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "polecam",
+          "ru": "полЭцам"
+        },
+        {
+          "pl": "polecasz",
+          "ru": "полЭцашь"
+        },
+        {
+          "pl": "poleca",
+          "ru": "полЭца"
+        }
+      ],
+      "ru_transcription": "полЭцач"
+    },
+    "translations": {
+      "ru": "рекомендовать"
+    }
   },
   "smakować": {
-    "lemma": "smakować",
-    "part_of_speech": "verb",
-    "translations": { "ru": "быть на вкус" },
-    "pronunciation": { 
-      "ru_transcription": "смакОвач",
-      "key_forms": [
-        { "pl": "smakuje", "ru": "смакУЕ" },
-        { "pl": "smakują", "ru": "смакУЁ" }
-      ]
+    "applied_rules": [],
+    "examples": [
+      {
+        "pl": "To smakuje wybornie.",
+        "ru": "Это вкусно на вкус.",
+        "ru_transcription": "то смакУЕ выборьнэ."
+      },
+      {
+        "pl": "Jak Ci smakuje?",
+        "ru": "Как тебе на вкус?",
+        "ru_transcription": "як ци смакУЕ?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy smakowali",
+        "pl2": "będziecie smakowali",
+        "pl3": "będą smakowali",
+        "sg1": "będę smakował/smakowała",
+        "sg2": "będziesz smakował/smakowała",
+        "sg3": "będzie smakował/smakowała"
+      },
+      "imperative": {},
+      "past_fem": {
+        "pl1": "smakowałyśmy",
+        "pl2": "smakowałyście",
+        "pl3": "smakowały",
+        "sg1": "smakowałam",
+        "sg2": "smakowałaś",
+        "sg3": "smakowała"
+      },
+      "past_masc": {
+        "pl1": "smakowaliśmy",
+        "pl2": "smakowaliście",
+        "pl3": "smakowali",
+        "sg1": "smakowałem",
+        "sg2": "smakowałeś",
+        "sg3": "smakował"
+      },
+      "past_neut": {
+        "sg3": "smakowało"
+      },
+      "present": {
+        "pl1": "smakujemy",
+        "pl2": "smakujecie",
+        "pl3": "smakują",
+        "sg1": "smakuję",
+        "sg2": "smakujesz",
+        "sg3": "smakuje"
+      }
     },
+    "lemma": "smakować",
     "morphology": {
       "aspect": "imperfective",
-      "transitivity": "intransitive",
-      "reflexive": false
+      "reflexive": false,
+      "transitivity": "intransitive"
     },
-    "inflection": {
-      "present": { "sg1": "smakuję", "sg2": "smakujesz", "sg3": "smakuje", "pl1": "smakujemy", "pl2": "smakujecie", "pl3": "smakują" },
-      "past_masc": { "sg1": "smakowałem", "sg2": "smakowałeś", "sg3": "smakował", "pl1": "smakowaliśmy", "pl2": "smakowaliście", "pl3": "smakowali" },
-      "past_fem": { "sg1": "smakowałam", "sg2": "smakowałaś", "sg3": "smakowała", "pl1": "smakowałyśmy", "pl2": "smakowałyście", "pl3": "smakowały" },
-      "past_neut": { "sg3": "smakowało" },
-      "future": { "sg1": "będę smakował/smakowała", "sg2": "będziesz smakował/smakowała", "sg3": "będzie smakował/smakowała", "pl1": "będziemy smakowali", "pl2": "będziecie smakowali", "pl3": "będą smakowali" },
-      "imperative": {}
-    },
-    "examples": [
-      { "pl": "To smakuje wybornie.", "ru": "Это вкусно на вкус.", "ru_transcription": "то смакУЕ выборьнэ." },
-      { "pl": "Jak Ci smakuje?", "ru": "Как тебе на вкус?", "ru_transcription": "як ци смакУЕ?" }
-    ],
+    "part_of_speech": "verb",
     "phrases_and_idioms": [],
-    "applied_rules": []
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "smakuje",
+          "ru": "смакУЕ"
+        },
+        {
+          "pl": "smakują",
+          "ru": "смакУЁ"
+        }
+      ],
+      "ru_transcription": "смакОвач"
+    },
+    "translations": {
+      "ru": "быть на вкус"
+    }
   },
   "spróbować": {
-    "lemma": "spróbować",
-    "part_of_speech": "verb",
-    "translations": { "ru": "попробовать" },
-    "pronunciation": { 
-      "ru_transcription": "спрубОвач",
-      "key_forms": [
-        { "pl": "spróbuję", "ru": "спрубУЕм" },
-        { "pl": "spróbujesz", "ru": "спрубУЕшь" },
-        { "pl": "spróbuje", "ru": "спрубУЕ" }
-      ]
+    "applied_rules": [
+      "ó",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Spróbuję tego deseru.",
+        "ru": "Попробую этот десерт.",
+        "ru_transcription": "спрубУЕм тэго дэСЭру."
+      },
+      {
+        "pl": "Spróbuj tej zupy!",
+        "ru": "Попробуй этот суп!",
+        "ru_transcription": "спруБУй тэй зупы!"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "spróbujemy",
+        "pl2": "spróbujecie",
+        "pl3": "spróbują",
+        "sg1": "spróbuję",
+        "sg2": "spróbujesz",
+        "sg3": "spróbuje"
+      },
+      "imperative": {
+        "pl1": "spróbujmy",
+        "pl2": "spróbujcie",
+        "sg2": "spróbuj"
+      },
+      "past_fem": {
+        "pl1": "spróbowałyśmy",
+        "pl2": "spróbowałyście",
+        "pl3": "spróbowały",
+        "sg1": "spróbowałam",
+        "sg2": "spróbowałaś",
+        "sg3": "spróbowała"
+      },
+      "past_masc": {
+        "pl1": "spróbowaliśmy",
+        "pl2": "spróbowaliście",
+        "pl3": "spróbowali",
+        "sg1": "spróbowałem",
+        "sg2": "spróbowałeś",
+        "sg3": "spróbował"
+      },
+      "past_neut": {
+        "sg3": "spróbowało"
+      },
+      "present": {}
     },
+    "lemma": "spróbować",
     "morphology": {
       "aspect": "perfective",
-      "transitivity": "transitive",
-      "reflexive": false
+      "reflexive": false,
+      "transitivity": "transitive"
     },
-    "inflection": {
-      "present": {},
-      "past_masc": { "sg1": "spróbowałem", "sg2": "spróbowałeś", "sg3": "spróbował", "pl1": "spróbowaliśmy", "pl2": "spróbowaliście", "pl3": "spróbowali" },
-      "past_fem": { "sg1": "spróbowałam", "sg2": "spróbowałaś", "sg3": "spróbowała", "pl1": "spróbowałyśmy", "pl2": "spróbowałyście", "pl3": "spróbowały" },
-      "past_neut": { "sg3": "spróbowało" },
-      "future": { "sg1": "spróbuję", "sg2": "spróbujesz", "sg3": "spróbuje", "pl1": "spróbujemy", "pl2": "spróbujecie", "pl3": "spróbują" },
-      "imperative": { "sg2": "spróbuj", "pl1": "spróbujmy", "pl2": "spróbujcie" }
-    },
-    "examples": [
-      { "pl": "Spróbuję tego deseru.", "ru": "Попробую этот десерт.", "ru_transcription": "спрубУЕм тэго дэСЭру." },
-      { "pl": "Spróbuj tej zupy!", "ru": "Попробуй этот суп!", "ru_transcription": "спруБУй тэй зупы!" }
-    ],
+    "part_of_speech": "verb",
     "phrases_and_idioms": [],
-    "applied_rules": ["ó", "ą"]
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "spróbuję",
+          "ru": "спрубУЕм"
+        },
+        {
+          "pl": "spróbujesz",
+          "ru": "спрубУЕшь"
+        },
+        {
+          "pl": "spróbuje",
+          "ru": "спрубУЕ"
+        }
+      ],
+      "ru_transcription": "спрубОвач"
+    },
+    "translations": {
+      "ru": "попробовать"
+    }
+  },
+  "zamawiać": {
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Zamawiam zupę.",
+        "ru": "Заказываю суп.",
+        "ru_transcription": "замаВЯМ зупэм."
+      },
+      {
+        "pl": "Co Pan zamawia?",
+        "ru": "Что Вы заказываете?",
+        "ru_transcription": "цо пан замаВЯ?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy zamawiali",
+        "pl2": "będziecie zamawiali",
+        "pl3": "będą zamawiali",
+        "sg1": "będę zamawiał/zamawiała",
+        "sg2": "będziesz zamawiał/zamawiała",
+        "sg3": "będzie zamawiał/zamawiała"
+      },
+      "imperative": {
+        "pl1": "zamawiajmy",
+        "pl2": "zamawiajcie",
+        "sg2": "zamawiaj"
+      },
+      "past_fem": {
+        "pl1": "zamawiałyśmy",
+        "pl2": "zamawiałyście",
+        "pl3": "zamawiały",
+        "sg1": "zamawiałam",
+        "sg2": "zamawiałaś",
+        "sg3": "zamawiała"
+      },
+      "past_masc": {
+        "pl1": "zamawialiśmy",
+        "pl2": "zamawialiście",
+        "pl3": "zamawiali",
+        "sg1": "zamawiałem",
+        "sg2": "zamawiałeś",
+        "sg3": "zamawiał"
+      },
+      "past_neut": {
+        "sg3": "zamawiało"
+      },
+      "present": {
+        "pl1": "zamawiamy",
+        "pl2": "zamawiacie",
+        "pl3": "zamawiają",
+        "sg1": "zamawiam",
+        "sg2": "zamawiasz",
+        "sg3": "zamawia"
+      }
+    },
+    "lemma": "zamawiać",
+    "morphology": {
+      "aspect": "imperfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "zamawiam",
+          "ru": "замаВЯМ"
+        },
+        {
+          "pl": "zamawiasz",
+          "ru": "замаВЯШЬ"
+        },
+        {
+          "pl": "zamawia",
+          "ru": "замаВЯ"
+        }
+      ],
+      "ru_transcription": "замавЯч"
+    },
+    "translations": {
+      "ru": "заказывать"
+    }
+  },
+  "zapraszać": {
+    "applied_rules": [
+      "sz",
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Zapraszamy do naszej restauracji!",
+        "ru": "Приглашаем в наш ресторан!",
+        "ru_transcription": "запрАшамы до нашэй рэстаурацьи!"
+      },
+      {
+        "pl": "Zaprasza Pan na kolację?",
+        "ru": "Вы приглашаете на ужин?",
+        "ru_transcription": "запрАша пан на колацьем?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy zapraszali",
+        "pl2": "będziecie zapraszali",
+        "pl3": "będą zapraszali",
+        "sg1": "będę zapraszał/zapraszała",
+        "sg2": "będziesz zapraszał/zapraszała",
+        "sg3": "będzie zapraszał/zapraszała"
+      },
+      "imperative": {
+        "pl1": "zapraszajmy",
+        "pl2": "zapraszajcie",
+        "sg2": "zapraszaj"
+      },
+      "past_fem": {
+        "pl1": "zapraszałyśmy",
+        "pl2": "zapraszałyście",
+        "pl3": "zapraszały",
+        "sg1": "zapraszałam",
+        "sg2": "zapraszałaś",
+        "sg3": "zapraszała"
+      },
+      "past_masc": {
+        "pl1": "zapraszaliśmy",
+        "pl2": "zapraszaliście",
+        "pl3": "zapraszali",
+        "sg1": "zapraszałem",
+        "sg2": "zapraszałeś",
+        "sg3": "zapraszał"
+      },
+      "past_neut": {
+        "sg3": "zapraszało"
+      },
+      "present": {
+        "pl1": "zapraszamy",
+        "pl2": "zapraszacie",
+        "pl3": "zapraszają",
+        "sg1": "zapraszam",
+        "sg2": "zapraszasz",
+        "sg3": "zaprasza"
+      }
+    },
+    "lemma": "zapraszać",
+    "morphology": {
+      "aspect": "imperfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [
+      {
+        "pl": "zapraszamy serdecznie",
+        "ru": "сердечно приглашаем"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "zapraszam",
+          "ru": "запрАшам"
+        },
+        {
+          "pl": "zapraszasz",
+          "ru": "запрАшашь"
+        },
+        {
+          "pl": "zaprasza",
+          "ru": "запрАша"
+        }
+      ],
+      "ru_transcription": "запрАшач"
+    },
+    "translations": {
+      "ru": "приглашать"
+    }
+  },
+  "zostawiać": {
+    "applied_rules": [
+      "ą"
+    ],
+    "examples": [
+      {
+        "pl": "Zostawiam napiwek.",
+        "ru": "Оставляю чаевые.",
+        "ru_transcription": "зостаВЯм напИвэк."
+      },
+      {
+        "pl": "Gdzie zostawiasz płaszcz?",
+        "ru": "Где оставляешь пальто?",
+        "ru_transcription": "гдзЕ зостаВЯшь пВАшч?"
+      }
+    ],
+    "inflection": {
+      "future": {
+        "pl1": "będziemy zostawiali",
+        "pl2": "będziecie zostawiali",
+        "pl3": "będą zostawiali",
+        "sg1": "będę zostawiał/zostawiała",
+        "sg2": "będziesz zostawiał/zostawiała",
+        "sg3": "będzie zostawiał/zostawiała"
+      },
+      "imperative": {
+        "pl1": "zostawiajmy",
+        "pl2": "zostawiajcie",
+        "sg2": "zostawiaj"
+      },
+      "past_fem": {
+        "pl1": "zostawiałyśmy",
+        "pl2": "zostawiałyście",
+        "pl3": "zostawiały",
+        "sg1": "zostawiałam",
+        "sg2": "zostawiałaś",
+        "sg3": "zostawiała"
+      },
+      "past_masc": {
+        "pl1": "zostawialiśmy",
+        "pl2": "zostawialiście",
+        "pl3": "zostawiali",
+        "sg1": "zostawiałem",
+        "sg2": "zostawiałeś",
+        "sg3": "zostawiał"
+      },
+      "past_neut": {
+        "sg3": "zostawiało"
+      },
+      "present": {
+        "pl1": "zostawiamy",
+        "pl2": "zostawiacie",
+        "pl3": "zostawiają",
+        "sg1": "zostawiam",
+        "sg2": "zostawiasz",
+        "sg3": "zostawia"
+      }
+    },
+    "lemma": "zostawiać",
+    "morphology": {
+      "aspect": "imperfective",
+      "reflexive": false,
+      "transitivity": "transitive"
+    },
+    "part_of_speech": "verb",
+    "phrases_and_idioms": [
+      {
+        "pl": "zostawiać napiwek",
+        "ru": "оставлять чаевые"
+      }
+    ],
+    "pronunciation": {
+      "key_forms": [
+        {
+          "pl": "zostawiam",
+          "ru": "зостаВЯм"
+        },
+        {
+          "pl": "zostawiasz",
+          "ru": "зостаВЯшь"
+        },
+        {
+          "pl": "zostawia",
+          "ru": "зостаВЯ"
+        }
+      ],
+      "ru_transcription": "зостаВЯч"
+    },
+    "translations": {
+      "ru": "оставлять"
+    }
   }
 }


### PR DESCRIPTION
## Summary
- add a suite of new verbs with full conjugations to the basic and restaurant datasets
- enrich noun, adjective, adverb, numeral, pronoun, particle, modal, interjection, interrogative, and punctuation entries for restaurant and general vocabulary
- update the dictionary index with new categories, file references, word counts, and refreshed statistics

## Testing
- not run (data updates only)

------
https://chatgpt.com/codex/tasks/task_e_68caa3ea1abc8330af583203a36a7447