### PR TITLE
Improve lesson UI interactions and styling

### DIFF
--- a/css/desktop/desktop-components.css
+++ b/css/desktop/desktop-components.css
@@ -83,6 +83,7 @@
   background-color: var(--primary-light);
   box-shadow: var(--shadow-md);
   transform: translateY(-2px);
+  color: var(--white);
 }
 
 .btn--primary:active {
@@ -208,8 +209,9 @@
   min-height: 320px;
   padding: var(--space-6);
   gap: var(--space-6);
-  box-shadow: var(--shadow-xl);
+  box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
   cursor: pointer;
+  overflow: hidden;
 }
 
 .category-card::before {
@@ -231,7 +233,7 @@
 
 .category-card:hover {
   transform: translateY(-8px) scale(1.02);
-  box-shadow: 0 20px 35px rgba(15, 23, 42, 0.18);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.18);
 }
 
 .category-card .card-icon {
@@ -329,10 +331,44 @@
   position: relative;
 }
 
+.dialog-speaker {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-4);
+  font-size: var(--font-size-lg);
+  margin-bottom: var(--space-3);
+}
+
+.dialog-speaker-name {
+  font-weight: var(--font-weight-semibold);
+  color: var(--primary-dark);
+  letter-spacing: 0.01em;
+}
+
+.dialog-translation {
+  display: none;
+  margin-top: var(--space-3);
+  padding-top: var(--space-3);
+  border-top: 1px solid var(--gray-100);
+  font-size: var(--font-size-sm);
+  line-height: var(--line-height-relaxed);
+  color: var(--gray-600);
+}
+
+.show-translations .dialog-translation {
+  display: block;
+}
+
 .dialog-line:hover {
   box-shadow: var(--shadow-lg);
   transform: translateX(4px);
   border-left-width: 6px;
+}
+
+.tabs__content-wrapper {
+  margin-top: var(--space-5);
+  gap: var(--space-6);
 }
 
 .dialog-controls {
@@ -391,6 +427,59 @@
   transform: translateY(-2px);
   box-shadow: var(--shadow-sm);
   z-index: 10;
+}
+
+/* ===== EXERCISES ===== */
+.exercises-container {
+  gap: var(--space-6);
+}
+
+.exercise {
+  padding: var(--space-6);
+  border-radius: var(--radius-xl);
+  box-shadow: var(--shadow-md);
+}
+
+.exercise__question {
+  padding: var(--space-4);
+}
+
+.exercise__actions {
+  flex-direction: row;
+  justify-content: flex-end;
+  gap: var(--space-3);
+  margin-top: var(--space-3);
+}
+
+.exercise__btn {
+  min-width: 160px;
+  padding: var(--space-3) var(--space-5);
+}
+
+.multiple-choice__options {
+  gap: var(--space-3);
+}
+
+.multiple-choice__option {
+  padding: var(--space-4);
+}
+
+.matching__container {
+  flex-direction: row;
+  align-items: flex-start;
+  gap: var(--space-5);
+}
+
+.matching__column {
+  flex: 1;
+}
+
+.matching__item {
+  padding: var(--space-3) var(--space-4);
+}
+
+.translation__input textarea {
+  min-height: 160px;
 }
 
 /* ===== TABLES ===== */

--- a/css/mobile/mobile-base.css
+++ b/css/mobile/mobile-base.css
@@ -352,6 +352,11 @@ pre code {
   font-family: 'Times New Roman', serif;
   color: var(--info-color);
   font-size: var(--font-size-xs);
+  margin-bottom: var(--space-2);
+}
+
+.text-transcription:empty {
+  display: none;
 }
 
 /* Утилиты для сенсорных устройств */

--- a/css/mobile/mobile-components.css
+++ b/css/mobile/mobile-components.css
@@ -13,6 +13,13 @@
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: var(--space-3);
+  flex-wrap: wrap;
+}
+
+.dialog-speaker-name {
+  font-weight: var(--font-weight-semibold);
+  color: var(--primary-dark);
 }
 
 .dialog-text {
@@ -23,10 +30,17 @@
 }
 
 .dialog-translation {
+  display: none;
   font-size: var(--font-size-sm);
   padding-top: var(--space-2);
   margin-top: var(--space-2);
   border-top: 1px solid var(--gray-100);
+  color: var(--gray-600);
+  line-height: var(--line-height-relaxed);
+}
+
+.show-translations .dialog-translation {
+  display: block;
 }
 
 /* Кликабельные слова на мобильных */
@@ -128,6 +142,26 @@
   padding: 0 var(--space-2);
 }
 
+.tabs__content {
+  display: none;
+  opacity: 0;
+  transform: translateY(8px);
+  transition: opacity var(--transition-base), transform var(--transition-base);
+}
+
+.tabs__content--active {
+  display: block;
+  opacity: 1;
+  transform: translateY(0);
+}
+
+.tabs__content-wrapper {
+  margin-top: var(--space-4);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
 .tabs__button {
   min-height: 44px;
   padding: var(--space-3) var(--space-4);
@@ -169,7 +203,7 @@
   text-decoration: none;
   overflow: hidden;
   background: transparent;
-  box-shadow: var(--shadow-lg);
+  box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
   transition: transform var(--transition-base), box-shadow var(--transition-base);
 }
 
@@ -231,7 +265,7 @@
 .category-card:hover,
 .category-card:focus-visible {
   transform: translateY(-4px);
-  box-shadow: var(--shadow-xl);
+  box-shadow: 0 16px 25px rgba(0, 0, 0, 0.12);
 }
 
 .category-card:hover::before,
@@ -487,6 +521,396 @@
     margin-bottom: var(--space-2);
     line-height: var(--line-height-relaxed);
   }
+
+/* Упражнения */
+.exercises-container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+
+.exercise {
+  background-color: var(--white);
+  padding: var(--space-4);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow-base);
+  border: 1px solid rgba(23, 25, 35, 0.05);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.exercise__header {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.exercise__title {
+  font-size: var(--font-size-xl);
+  color: var(--primary-dark);
+  font-weight: var(--font-weight-semibold);
+}
+
+.exercise__description {
+  color: var(--gray-600);
+  line-height: var(--line-height-relaxed);
+}
+
+.exercise__progress {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.exercise__progress-bar {
+  position: relative;
+  width: 100%;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background-color: var(--gray-200);
+  overflow: hidden;
+}
+
+.exercise__progress-fill {
+  position: absolute;
+  inset: 0;
+  width: 0%;
+  border-radius: inherit;
+  background: linear-gradient(135deg, var(--secondary-color), var(--primary-color));
+  transition: width var(--transition-slow);
+}
+
+.exercise__progress-text {
+  font-size: var(--font-size-sm);
+  color: var(--gray-600);
+  font-weight: var(--font-weight-medium);
+}
+
+.exercise__content {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.exercise__questions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+}
+
+.exercise__question {
+  background-color: rgba(221, 184, 146, 0.12);
+  border-radius: var(--radius-md);
+  padding: var(--space-3);
+  border: 1px solid rgba(221, 184, 146, 0.3);
+}
+
+.exercise__question-text {
+  color: var(--gray-700);
+  line-height: var(--line-height-relaxed);
+}
+
+.fill-blank__sentence {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  align-items: center;
+}
+
+.fill-blank__word {
+  font-weight: var(--font-weight-medium);
+}
+
+.fill-blank__input {
+  min-width: 90px;
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-base);
+  border: 2px solid rgba(23, 25, 35, 0.15);
+  background-color: var(--white);
+  transition: border-color var(--transition-base), box-shadow var(--transition-base);
+  text-align: center;
+}
+
+.fill-blank__input:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(139, 69, 19, 0.15);
+}
+
+.fill-blank__input--correct {
+  border-color: var(--success-color);
+  background-color: rgba(92, 184, 92, 0.12);
+}
+
+.fill-blank__input--incorrect {
+  border-color: var(--error-color);
+  background-color: rgba(217, 83, 79, 0.12);
+}
+
+.multiple-choice__options {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.multiple-choice__option {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-3);
+  border-radius: var(--radius-base);
+  border: 2px solid transparent;
+  background-color: var(--white);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
+}
+
+.multiple-choice__option:hover {
+  transform: translateY(-2px);
+  box-shadow: var(--shadow-md);
+}
+
+.multiple-choice__option--selected {
+  border-color: var(--primary-color);
+  box-shadow: var(--shadow-md);
+}
+
+.multiple-choice__option--correct {
+  border-color: var(--success-color);
+  background-color: rgba(92, 184, 92, 0.1);
+}
+
+.multiple-choice__option--incorrect {
+  border-color: var(--error-color);
+  background-color: rgba(217, 83, 79, 0.1);
+}
+
+.multiple-choice__radio {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  border: 2px solid rgba(23, 25, 35, 0.2);
+  position: relative;
+  flex-shrink: 0;
+}
+
+.multiple-choice__option--selected .multiple-choice__radio,
+.multiple-choice__option--correct .multiple-choice__radio {
+  border-color: var(--primary-color);
+}
+
+.multiple-choice__option--correct .multiple-choice__radio {
+  border-color: var(--success-color);
+}
+
+.multiple-choice__option--incorrect .multiple-choice__radio {
+  border-color: var(--error-color);
+}
+
+.multiple-choice__option--selected .multiple-choice__radio::after,
+.multiple-choice__option--correct .multiple-choice__radio::after,
+.multiple-choice__option--incorrect .multiple-choice__radio::after {
+  content: '';
+  position: absolute;
+  inset: 3px;
+  border-radius: 50%;
+}
+
+.multiple-choice__option--selected .multiple-choice__radio::after {
+  background: var(--primary-color);
+}
+
+.multiple-choice__option--correct .multiple-choice__radio::after {
+  background: var(--success-color);
+}
+
+.multiple-choice__option--incorrect .multiple-choice__radio::after {
+  background: var(--error-color);
+}
+
+.multiple-choice__text {
+  flex: 1;
+  color: var(--gray-700);
+}
+
+.exercise__actions {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+
+.exercise__btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--space-2);
+  padding: var(--space-3);
+  border-radius: var(--radius-base);
+  font-weight: var(--font-weight-medium);
+  font-size: var(--font-size-base);
+  transition: background-color var(--transition-base), color var(--transition-base), transform var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.exercise__btn i {
+  font-size: 0.9rem;
+}
+
+.exercise__btn--check {
+  background-color: var(--primary-color);
+  color: var(--white);
+  box-shadow: var(--shadow-sm);
+}
+
+.exercise__btn--check:hover {
+  background-color: var(--primary-light);
+  box-shadow: var(--shadow-md);
+  transform: translateY(-1px);
+}
+
+.exercise__btn--hint {
+  background-color: rgba(221, 184, 146, 0.25);
+  color: var(--primary-dark);
+}
+
+.exercise__btn--hint:hover {
+  background-color: rgba(221, 184, 146, 0.4);
+}
+
+.exercise__btn--reset {
+  background-color: transparent;
+  border: 1px solid var(--gray-300);
+  color: var(--gray-600);
+}
+
+.exercise__btn--reset:hover {
+  background-color: var(--gray-100);
+}
+
+.exercise__feedback {
+  display: none;
+  padding: var(--space-3);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-base);
+  line-height: var(--line-height-relaxed);
+  margin-top: var(--space-3);
+}
+
+.exercise__feedback--show {
+  display: block;
+}
+
+.exercise__feedback--success {
+  background-color: rgba(92, 184, 92, 0.15);
+  color: var(--success-color);
+}
+
+.exercise__feedback--partial {
+  background-color: rgba(250, 173, 20, 0.15);
+  color: var(--warning-color);
+}
+
+.exercise__feedback--error {
+  background-color: rgba(217, 83, 79, 0.15);
+  color: var(--error-color);
+}
+
+.exercise__score {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-weight: var(--font-weight-semibold);
+  margin-bottom: var(--space-2);
+}
+
+.exercise__message {
+  color: var(--gray-700);
+}
+
+.exercise__hint {
+  display: none;
+  margin-top: var(--space-2);
+  padding: var(--space-3);
+  border-left: 3px solid var(--primary-color);
+  background-color: rgba(139, 69, 19, 0.08);
+  border-radius: var(--radius-md);
+  color: var(--gray-700);
+  line-height: var(--line-height-relaxed);
+}
+
+.exercise__hint--show {
+  display: block;
+}
+
+.matching__container {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.matching__column {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+
+.matching__column h4 {
+  font-size: var(--font-size-base);
+  color: var(--gray-700);
+  margin-bottom: var(--space-1);
+}
+
+.matching__item {
+  padding: var(--space-2) var(--space-3);
+  border-radius: var(--radius-base);
+  border: 1px solid rgba(23, 25, 35, 0.15);
+  background-color: var(--white);
+  box-shadow: var(--shadow-sm);
+  transition: transform var(--transition-fast), box-shadow var(--transition-fast), border-color var(--transition-fast);
+  cursor: pointer;
+}
+
+.matching__item:hover {
+  transform: translateY(-1px);
+  box-shadow: var(--shadow-md);
+}
+
+.matching__item--selected {
+  border-color: var(--primary-color);
+  box-shadow: var(--shadow-md);
+}
+
+.matching__item--matched {
+  background-color: rgba(221, 184, 146, 0.3);
+  border-color: rgba(221, 184, 146, 0.6);
+  cursor: default;
+  pointer-events: none;
+}
+
+.matching__item--correct {
+  background-color: rgba(92, 184, 92, 0.15);
+  border-color: var(--success-color);
+}
+
+.matching__item--incorrect {
+  background-color: rgba(217, 83, 79, 0.15);
+  border-color: var(--error-color);
+}
+
+.translation__input textarea {
+  width: 100%;
+  border: 2px solid rgba(23, 25, 35, 0.1);
+  border-radius: var(--radius-base);
+  padding: var(--space-3);
+  resize: vertical;
+  min-height: 120px;
+  background-color: var(--white);
+}
+
+.translation__input textarea:focus {
+  border-color: var(--primary-color);
+  box-shadow: 0 0 0 3px rgba(139, 69, 19, 0.12);
+}
 
   .grammar-topic__content li:last-child {
     margin-bottom: 0;

--- a/css/tablet/tablet-adjustments.css
+++ b/css/tablet/tablet-adjustments.css
@@ -326,6 +326,23 @@ html {
   font-size: var(--font-size-base);
 }
 
+.exercises-container {
+  gap: var(--space-6);
+}
+
+.tabs__content-wrapper {
+  margin-top: var(--space-5);
+}
+
+.matching__container {
+  flex-direction: row;
+  gap: var(--space-4);
+}
+
+.matching__column {
+  flex: 1;
+}
+
 /* ===== CLICKABLE ELEMENTS ADJUSTMENTS ===== */
 .clickable-word {
   padding: 3px 6px;

--- a/js/components/lesson.js
+++ b/js/components/lesson.js
@@ -147,14 +147,16 @@ export class LessonComponent {
 
   generateContentHTML() {
     return `
-      <div class="tabs__content tabs__content--active" data-content="main">
-        ${this.generateDialogHTML()}
-      </div>
-      <div class="tabs__content" data-content="grammar">
-        ${this.generateGrammarHTML()}
-      </div>
-      <div class="tabs__content" data-content="exercises">
-        ${this.generateExercisesHTML()}
+      <div class="tabs__content-wrapper">
+        <div class="tabs__content tabs__content--active" data-content="main">
+          ${this.generateDialogHTML()}
+        </div>
+        <div class="tabs__content" data-content="grammar">
+          ${this.generateGrammarHTML()}
+        </div>
+        <div class="tabs__content" data-content="exercises">
+          ${this.generateExercisesHTML()}
+        </div>
       </div>
     `;
   }
@@ -224,6 +226,7 @@ export class LessonComponent {
   generateDialogLinesHTML() {
     return this.lessonData.content
       .map((line, index) => {
+        const speaker = line.speaker || '';
         const wordsHTML = (line.words || [])
           .map(word => {
             // ИСПРАВЛЕНО: Получаем перевод асинхронно, но показываем загрузку
@@ -240,12 +243,12 @@ export class LessonComponent {
           .join(' ');
           
         return `
-          <div class="dialog-line" 
-               data-speaker="${line.speaker.toLowerCase()}"
+          <div class="dialog-line"
+               data-speaker="${speaker.toLowerCase()}"
                data-line-index="${index}">
-            
+
             <div class="dialog-speaker">
-              ${line.speaker}
+              <span class="dialog-speaker-name">${speaker}</span>
               <button class="audio-play-btn"
                       data-text="${line.sentence}"
                       title="Озвучить"
@@ -297,9 +300,9 @@ export class LessonComponent {
 
   initializeComponents() {
     console.log('🔧 Инициализируем компоненты урока');
-    
+
     // Инициализируем табы
-    const tabsElement = this.container.querySelector('[data-tabs]');
+    const tabsElement = this.container.querySelector('[data-tabs="lesson-tabs"]');
     if (tabsElement) {
       this.tabs = new TabsComponent(tabsElement);
     }


### PR DESCRIPTION
## Summary
- soften category card shadows and update tab containers to hide inactive panels while enabling dedicated speaker styling in dialogues
- ensure lesson dialogues render transcription data and toggle translations through the dialog container with the lesson tabs wired to TabsComponent
- add comprehensive exercise styling across mobile, tablet, and desktop breakpoints for all activity types

## Testing
- not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68cb3866bc088330828c2b57c68f5ac4