### PR TITLE
Improve mobile UI readability and fix sentence translations

### DIFF
--- a/css/desktop/desktop-components.css
+++ b/css/desktop/desktop-components.css
@@ -212,6 +212,23 @@
   box-shadow: 0 10px 18px rgba(15, 23, 42, 0.12);
   cursor: pointer;
   overflow: hidden;
+  color: var(--white);
+}
+
+.category-card,
+.category-card h4,
+.category-card p,
+.category-card .card-footer,
+.category-card .card-footer span,
+.category-card .card-icon,
+.category-card .card-icon i,
+.category-card .arrow-icon {
+  color: var(--white);
+}
+
+.category-card .card-content p,
+.category-card .card-footer {
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .category-card::before {
@@ -305,6 +322,22 @@
   margin-bottom: -2px;
   white-space: nowrap;
   position: relative;
+}
+
+.tabs__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.75rem;
+  height: 1.75rem;
+  padding: 0 var(--space-2);
+  margin-left: var(--space-2);
+  border-radius: var(--radius-full);
+  background-color: var(--gray-200);
+  color: var(--gray-700);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1;
 }
 
 .tabs__button:hover {
@@ -850,6 +883,22 @@
   flex-direction: column;
   gap: var(--space-2);
   color: var(--gray-700);
+}
+
+.conjugation-table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.conjugation-table th:first-child,
+.conjugation-table td:first-child {
+  width: 34%;
+}
+
+.conjugation-table th,
+.conjugation-table td {
+  width: 33%;
+  text-align: left;
 }
 
 .word-breakdown-list strong {

--- a/css/mobile/mobile-components.css
+++ b/css/mobile/mobile-components.css
@@ -281,6 +281,22 @@
   line-height: var(--line-height-relaxed);
 }
 
+.conjugation-table {
+  width: 100%;
+  table-layout: fixed;
+}
+
+.conjugation-table th:first-child,
+.conjugation-table td:first-child {
+  width: 34%;
+}
+
+.conjugation-table th,
+.conjugation-table td {
+  width: 33%;
+  text-align: left;
+}
+
 .pronunciation,
 .pronunciation-guide {
   display: flex;
@@ -308,6 +324,22 @@
   min-width: auto;
   text-align: center;
   touch-action: manipulation;
+}
+
+.tabs__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  height: 1.5rem;
+  padding: 0 var(--space-2);
+  margin-left: var(--space-2);
+  border-radius: var(--radius-full);
+  background-color: var(--gray-200);
+  color: var(--gray-700);
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  line-height: 1;
 }
 
 .tabs--chips .tabs__button {
@@ -388,6 +420,22 @@
   background: transparent;
   box-shadow: 0 10px 15px rgba(0, 0, 0, 0.1);
   transition: transform var(--transition-base), box-shadow var(--transition-base);
+}
+
+.category-card,
+.category-card h4,
+.category-card p,
+.category-card .card-footer,
+.category-card .card-footer span,
+.category-card .card-icon,
+.category-card .card-icon i,
+.category-card .arrow-icon {
+  color: var(--white);
+}
+
+.category-card .card-content p,
+.category-card .card-footer {
+  color: rgba(255, 255, 255, 0.9);
 }
 
 .category-card::before {
@@ -579,15 +627,21 @@
 
 /* Элементы управления диалогом */
 .dialog-controls {
-  flex-direction: column;
-  gap: var(--space-3);
-  align-items: stretch;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: space-between;
+  flex-wrap: wrap;
+  gap: var(--space-4);
   padding: var(--space-3);
 }
 
 .translation-toggle {
-  width: 100%;
-  justify-content: center;
+  display: flex;
+  align-items: center;
+  justify-content: flex-start;
+  flex: 1 1 220px;
+  gap: var(--space-3);
 }
 
   .translation-toggle label {
@@ -597,6 +651,7 @@
     cursor: pointer;
     font-size: var(--font-size-base);
     font-weight: var(--font-weight-medium);
+    flex-wrap: nowrap;
   }
 
   .translation-toggle__label {
@@ -608,8 +663,8 @@
     display: inline-flex;
     align-items: center;
     justify-content: flex-start;
-    width: 54px;
-    height: 30px;
+    width: 42px;
+    height: 24px;
     flex-shrink: 0;
     border-radius: var(--radius-full);
     background-color: var(--gray-300);
@@ -623,10 +678,10 @@
   .toggle-switch::after {
     content: '';
     position: absolute;
-    top: 3px;
-    left: 3px;
-    width: 24px;
-    height: 24px;
+    top: 2px;
+    left: 2px;
+    width: 20px;
+    height: 20px;
     border-radius: 50%;
     background-color: var(--white);
     box-shadow: 0 2px 6px rgba(15, 23, 42, 0.2);
@@ -641,12 +696,12 @@
   }
 
   .toggle-switch--active::after {
-    transform: translateX(24px);
+    transform: translateX(18px);
     box-shadow: 0 2px 8px rgba(15, 23, 42, 0.3);
   }
 
   .translation-toggle__state {
-    min-width: 48px;
+    min-width: 44px;
     text-align: center;
     font-size: 0.75rem;
     font-weight: var(--font-weight-semibold);
@@ -1101,17 +1156,25 @@
 
   /* Аудио кнопки */
   .audio-controls {
-    display: flex;
-    justify-content: center;
+    display: inline-flex;
+    align-items: center;
+    justify-content: flex-end;
+    flex: 0 0 auto;
+    gap: var(--space-3);
+    width: auto;
+  }
+
+  .audio-controls .btn {
+    white-space: nowrap;
   }
 
   .audio-play-btn {
     width: 40px;
     height: 40px;
     font-size: var(--font-size-base);
-  min-width: 40px;
-  min-height: 40px;
-}
+    min-width: 40px;
+    min-height: 40px;
+  }
 
 /* Заголовки уроков */
 .lesson-header-box {


### PR DESCRIPTION
## Summary
- ensure category card text and conjugation tables render with consistent contrast on mobile and desktop
- add badge styling for lesson tabs and refine mobile dialog controls and toggle switch sizing
- await dictionary lookups when opening sentence details so word translations populate correctly

## Testing
- Not run (not provided)


------
https://chatgpt.com/codex/tasks/task_e_68cc6d54b10483309273c53996674a32